### PR TITLE
Some suggestions and ideas for the manual of future package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,10 +78,10 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     There are no big changes here, but the change to the resistor code (maybe one of the most used by the package) well deserves a minor version bump. A couple of new components, and several minor fixes.
 
-    - New component: new kind of current tap (suggested by [EEpchi and Dr4UX on GitHub](https://github.com/circuitikz/circuitikz/issues/807))
+    - New component: new kind of current tap (suggested by [EEpchi and Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/issues/807))
     - New arrow tip `Jack Tap` to help drawing jack connectors (suggested by [Anisio Rogerio Braga](https://github.com/circuitikz/circuitikz/issues/806))
-    - Change the drawing of the thermocouple (suggested by [Dr4UX on GitHub](https://github.com/circuitikz/circuitikz/issues/811))
-    - Change and enhancement to the drawing of the American resistors (triggered by [Dr4UX on GitHub](https://github.com/circuitikz/circuitikz/issues/814)), fixing a long-standing small asymmetry that nobody noticed
+    - Change the drawing of the thermocouple (suggested by [Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/issues/811))
+    - Change and enhancement to the drawing of the American resistors (triggered by [Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/issues/814)), fixing a long-standing small asymmetry that nobody noticed
     - Minor adjustment for joins in `viscoe` component
     - Minor additions (`rectjoinfill`) and fixes in documentation
 
@@ -89,7 +89,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     Several new components and a bug fix for a nasty long-standing bug about switching diode types.
 
-    - Added a Relais-Shape (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/pull/795)
+    - Added a Relais-Shape (contributed by [Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/pull/795))
     - Added a center tap anchor for tube filament (suggested by [user bogger33 on GitHub](https://github.com/circuitikz/circuitikz/issues/792))
     - Added neon lamps (two versions, suggested by [user bogger33 on GitHub](https://github.com/circuitikz/circuitikz/issues/793))
     - Added a configurable spark gap (suggested by [user bogger33 on GitHub](https://github.com/circuitikz/circuitikz/issues/800))
@@ -141,9 +141,9 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - The symbol in European logic ports is now rotation-invariant, and its font can be customized (suggested by [user `@sputeanus` on GitHub](https://github.com/circuitikz/circuitikz/issues/730))
     - Added a couple of "blank" (no symbol) European logic ports
-    - Added new "traditional" switches (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/issues/734))
+    - Added new "traditional" switches (contributed by [Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/issues/734))
     - Added configurability (color, thickness, dash) to switch arrows
-    - Added "eyw"-symbol (reverse star) for "oo"-type sources (contributed by [Jakob "DraUX" on GitHub](https://github.com/circuitikz/circuitikz/pull/742))
+    - Added "eyw"-symbol (reverse star) for "oo"-type sources (contributed by [Jakob Leide on GitHub](https://github.com/circuitikz/circuitikz/pull/742))
     - Added configurable open shape to the sinusoidal current source (contributed by [Maximilian Martin](https://github.com/circuitikz/circuitikz/pull/737))
     - Documentation fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
     - Fix a problem with dc symbol dashes, see [this issue on GitHub](https://github.com/circuitikz/circuitikz/issues/897)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
+    - Make the value of `bipoles/length` usable by `\ctikzvalof` (by [Jonathan P. Spratte](https://github.com/circuitikz/circuitikz/pull/900))
 
 * Version 1.8.3 (2025-11-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
     The main highlights of this release is a new appearance (optional!) for blocks representing filters, and some option to add style to the inner drawings of (most) blocks.
 
     - Add a new set of filter blocks, add options for inner block drawings (by Romano)
+    - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
 
 * Version 1.8.3 (2025-11-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
 * Version 1.8.4 (unreleased)
 
+    The main highlights of this release is a new appearance (optional!) for blocks representing filters, and some option to add style to the inner drawings of (most) blocks.
+
+    - Add a new set of filter blocks, add options for inner block drawings (by Romano)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
 
 * Version 1.8.3 (2025-11-23)
-    
+
     The main highlight of this version is the fix of the oo-type sources and transformers. They used parameters different from width and height to define the shape, and the anchors were not stable (and some of them were plain wrong). It also adds several capabilities to them (anchors, additional windings, and so on).
     Additionally, IGT thyristors and a couple of generic shapes (AC/DC symbols) have been added.
-    
+
     - Add anchors, additional winding, global scale switch and symbol rotation to the oo-type component, suggested by [Jakob Leide](https://github.com/circuitikz/circuitikz/issues/886)
     - Add IGCT thyristors by [Paul Sacco](https://github.com/circuitikz/circuitikz/pull/881)
     - Add ac/dc symbols (by Romano)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The major changes among the different CircuiTikZ versions are listed here. See <
 
     - Add a new set of filter blocks, add options for inner block drawings (by Romano)
     - Add the option to *not* draw the wiper in rotary switches, suggested by [@kabenyuk and @cis in this Q&A](https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display)
+    - Fix a problem with dc symbol dashes, see [this issue on GitHub](https://github.com/circuitikz/circuitikz/issues/897)
     - Minor fixes in the manual (thanks [quark67](https://github.com/circuitikz/circuitikz/issues/891)!)
 
 * Version 1.8.3 (2025-11-23)

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -1366,7 +1366,7 @@ All can be varied using the \verb!\ctikzset! command, anywhere in the code.
 Note that the details of the parameters that are not described in the manual can change in the future, so be ready to use a fixed version of the package (the ones with the specific number, like \verb|circuitikz-0.9.3|) if you dig into them.
 
 \paragraph{Components size}\label{sec:pgfcircRlen}
-Perhaps the most important parameter is \IndexKey{bipoles/length}  (default \SI{1.4}{cm}), which
+Perhaps the most important parameter is \IndexKey{bipoles/length}  (default \SI{1.4}{cm}, you can use the currently set value with \verb!\ctikzvalof{bipoles/length}!), which
 can be interpreted as the length of a resistor (including reasonable connections): all other lengths are relative to this value. For instance:
 
 \begin{LTXexample}[pos=t,varwidth=true]

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -2410,7 +2410,7 @@ For the \texttt{photoresistor} and the two ``flavors'' of the light-dependent re
     \rdivider{1}\rdivider{2}\rdivider{3}\rdivider{4}
 \end{center}}
 
-\paragraph{Details of American (``zig-zag'') resistors.\label{sec:zigzag-details}} American (zig-zag) resistors have a little joining problem\footnote{Noticed by \href{https://github.com/circuitikz/circuitikz/issues/811}{user Dr4UX on GitHub} and later \href{https://github.com/circuitikz/circuitikz/discussions/814}{discussed here}.} with the leading wires if the thickness is greater than two. In the following drawing you can see the problem when the thickness grows from 1 to 4.
+\paragraph{Details of American (``zig-zag'') resistors.\label{sec:zigzag-details}} American (zig-zag) resistors have a little joining problem\footnote{Noticed by \href{https://github.com/circuitikz/circuitikz/issues/811}{Jakob Leide on GitHub} and later \href{https://github.com/circuitikz/circuitikz/discussions/814}{discussed here}.} with the leading wires if the thickness is greater than two. In the following drawing you can see the problem when the thickness grows from 1 to 4.
 
 \splat
 
@@ -3040,7 +3040,7 @@ Notice that if you choose the dashed style, the noise sources are fillable:
     \endgroup
 \end{groupdesc}
 
-The transformer shapes vector group options can be specified for the primary (\IndexKey[prim]{prim=\emph{value}}), the secondary (\IndexKey[sec]{sec=\emph{value}}) and tertiary (\IndexKey[tert]{tert=\emph{value}}) three-phase vector groups: the value can be one of \IndexKey{delta}, \IndexKey{wye}, \IndexKey{eyw}\footnote{The \IndexKey{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob ``DraUX'' on GitHub}} and \IndexKey{zig}.
+The transformer shapes vector group options can be specified for the primary (\IndexKey[prim]{prim=\emph{value}}), the secondary (\IndexKey[sec]{sec=\emph{value}}) and tertiary (\IndexKey[tert]{tert=\emph{value}}) three-phase vector groups: the value can be one of \IndexKey{delta}, \IndexKey{wye}, \IndexKey{eyw}\footnote{The \IndexKey{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob Leide on GitHub}} and \IndexKey{zig}.
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
@@ -3689,7 +3689,7 @@ Here you'll find bipoles that are not easily grouped in the categories above.
     \circuitdescbip*{afuse}{Asymmetric fuse}{asymmetric fuse}
     \circuitdescbip{wfuse}{``wiggly'' fuse}{wiggly fuse}()[left/110/0.2, right/70/0.2]
     \circuitdescbip*{relais}{Relais\footnotemark}{}
-    \footnotetext{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/795}{Jakob ``DraUX''}}
+    \footnotetext{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/795}{Jakob Leide}}
     \circuitdescbip{squid}{Squid}{}
     \circuitdescbip{barrier}{Barrier}{}
     \circuitdescbip{openbarrier}{Open barrier}{}
@@ -3955,7 +3955,7 @@ While the horizontal line will be drawn with the current path values, you can ch
 The main arrow shapes in \Circuitikz{} are really shapes, used as pseudo-arrows in lot of places in the packages (for transistors, flows, currents, and so on). The first three arrows are magnified by a factor~3 in the boxes below; for the \texttt{trarrow}, the anchor \texttt{tip} is exactly on the tip and \texttt{btip} is slightly receded.
 
 \begin{groupdesc}
-    \circuitdesc[3]{currarrow}{Arrow for current and voltage}{}(center/0/0.2)
+    \circuitdesc[3]{currarrow}{Arrow for current and voltage}{}(center/45/0.2,tip/-45/0.2)
     \circuitdesc[3]{inputarrow}{Arrow that is anchored at its tip, useful for block diagrams.}{}(center/0/0.2)
     \circuitdesc[3]{trarrow}{Arrow the same size of \texttt{currarrow} but only filled.}{}(center/90/0.2, tip/0/0.2, btip/-90/0.2)
     \circuitdesc{flowarrow}{Arrow used for the flows}{$I_p$}(south/-90/0.2, east/0/0.2, west/180/0.2, center/45/0.2)
@@ -6747,7 +6747,7 @@ These are all of the to-style type:
     \circuitdescbip[cncs]{closing normal closed switch}{Closing normally closed switch}{cncs}
     \circuitdescbip[onos]{opening normal open switch}{Opening normally open switch}{onos}
     \circuitdescbip[cnos]{closing normal open switch}{Closing normally open switch\footnotemark}{cnos}
-    \footnotetext{These last four were contributed by \href{https://tex.stackexchange.com/questions/693446/new-switch-components-for-circuitikz}{Jakob ``DraUX''}}
+    \footnotetext{These last four were contributed by \href{https://tex.stackexchange.com/questions/693446/new-switch-components-for-circuitikz}{Jakob Leide}}
     \circuitdescbip[pushbutton]{push button}{Normally open push button}{normally open push button, nopb}(tip/0/0.2, mid/-90/0.2)
     \circuitdescbip[ncpushbutton]{normally closed push button}{Normally closed push button}{ncpb}(tip/0/0.2, mid/-90/0.2)
     \circuitdescbip[pushbuttonc]{normally open push button closed}{Normally open push button (in closed position)}{nopbc}(tip/0/0.2, mid/-90/0.2)
@@ -9124,7 +9124,7 @@ However, you can override the properties \IndexKey{voltage/distance from node} (
 \end{LTXexample}
 
 You can also use a global \texttt{ctikzset} on the key \texttt{voltage/distance from node} (and similar) that will act as a default value. Notice however that the specific component value \textbf{overrides} the global one, and several components have pre-defined overrides, so they will ignore the default value. The components that have out of the box predefined overrides for \IndexKey[distance from node, override]{distance from node} are \texttt{generic}, \texttt{ageneric}, \texttt{fullgeneric} and \texttt{memristor} (set to \texttt{0.4}), and the ones that have it for \texttt{bump b} are
-\texttt{generic}, \texttt{ageneric}, \texttt{fullgeneric}, \texttt{memristor}, \texttt{tline}, \texttt{varistor}, \texttt{photoresistor}, \texttt{thermistor}, \texttt{thermistorntc}, \texttt{thermistorptc}, \texttt{ccapacitor}, \texttt{emptyzzdiode}, \texttt{fullzzdiode}, \texttt{emptythyristor}, \texttt{fullthyristor}, \texttt{emptytriac} and \texttt{fulltriac},, with several values (you can look at them in the file \texttt{pgfcirc.defines.tex})
+\texttt{generic}, \texttt{ageneric}, \texttt{fullgeneric}, \texttt{memristor}, \texttt{tline}, \texttt{varistor}, \texttt{photoresistor}, \texttt{thermistor}, \texttt{thermistorntc}, \texttt{thermistorptc}, \texttt{ccapacitor}, \texttt{emptyzzdiode}, \texttt{fullzzdiode}, \texttt{emptythyristor}, \texttt{fullthyristor}, \texttt{emptytriac} and \texttt{fulltriac},, with several values (you can look at them in the file \texttt{pgfcirc.defines.tex}).\footnote{To achieve consistent results of \texttt{voltage/distance from node=0} refer to this solution by Jakob Leide on \href{https://tex.stackexchange.com/questions/757418/circuitikz-inconsistent-behaviour-of-voltage-distance-from-node}{tex.stackexchange.com}.}
 
 
 Notice also that normally \texttt{distance from node} is a relative displacement, computed on the node-component wire. So that this will put the start and stop point $1/4$ of the way between node and component:
@@ -9977,7 +9977,7 @@ The meaning of the anchors is the following:
 \item
     \IndexKey{Vcont1} and \IndexKey{Vcont2} are the control points for the curved arrow (see the examples above); in the case of straight arrows or american-style voltages, they are set at the midpoint between \texttt{Vfrom} and \texttt{Vto}.
 \item
-    \IndexKey{Vlab} is where the text label for the voltage is normally positioned. The anchor used for such label is available using the auxiliary macro \verb|\ctikzgetanchor| (see below)
+    \IndexKey{Vlab} is where the text label for the voltage is normally positioned. The anchor used for such label is available using the auxiliary macro \verb|\ctikzgetanchor| (see below). Consider the default \verb|inner sep=2pt| of voltage label nodes.
 \item
     \IndexKey{Ipos} and \IndexKey{Fpos} are the position for the arrowhead or the small flow arrow (which is a \texttt{currarrow} or \texttt{flowarrow} node normally) is positioned, respectively. The label is then added to the correct side of it using the anchor available via \verb|\ctikzgetanchor| (see below,~\ref{sec:advances-aux-info}). In this case, the exact position of the label is not available if you do not position the element, for this there is no \texttt{Flab} or \texttt{Ilab} coordinate; you have to use the \texttt{Fpos} and \texttt{Ipos} coordinate with the corresponding \IndexKey{Ilab} and \IndexKey{Flab} anchors.
 \end{itemize}
@@ -10136,8 +10136,8 @@ Using the advanced voltage interface mechanism, you can for example design volta
     \coordinate (#2-Vcenter) at ($(#2-Vfrom)!0.5!(#2-Vto)$);
     % draw an arrow of a fixed size around that center and on the same line
     \draw[-Triangle, #4] ($(#2-Vcenter)!#1!(#2-Vfrom)$) -- ($(#2-Vcenter)!#1!(#2-Vto)$);
-    % position the label as in the normal voltages
-    \node[anchor=\ctikzgetanchor{#2}{Vlab}, #4] at (#2-Vlab) {#3};
+    % position the label as in the normal voltages (inner sep of voltage labels is 2pt per default)
+    \node[anchor=\ctikzgetanchor{#2}{Vlab}, inner sep=2pt, #4] at (#2-Vlab) {#3};
 }
 \end{lstlisting}
 \NewDocumentCommand{\fixedvlen}{O{0.5cm} m m O{}}{% [semilength]{node}{label}[extra options]
@@ -10146,7 +10146,7 @@ Using the advanced voltage interface mechanism, you can for example design volta
     % draw an arrow of a fixed size around that center and on the same line
     \draw[-Triangle, #4] ($(#2-Vcenter)!#1!(#2-Vfrom)$) -- ($(#2-Vcenter)!#1!(#2-Vto)$);
     % position the label as in the normal voltages
-    \node[anchor=\ctikzgetanchor{#2}{Vlab}, #4] at (#2-Vlab) {#3};
+    \node[anchor=\ctikzgetanchor{#2}{Vlab}, inner sep=2pt, #4] at (#2-Vlab) {#3};
 }
 
 \begin{LTXexample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3827,6 +3827,26 @@ The node text is positioned above the symbol, at a distance controlled by the ke
 
 As shown in the example above, the \texttt{dc symbols} has an additional options. By default the lower line of the symbol has two segments, but you can change this with the \texttt{circuitikz} key \IndexKey{dc symbol/segments} (with also the direct key, at \TikZ{} level, \IndexKey{dc symbol segments} (default \texttt{2})) with any value greater than 0.
 
+Additionally, you can change the relative thickness of the bottom line with the key \texttt{dc symbols/relative thickness} (default \texttt{1}).
+
+\begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
+    \begin{tikzpicture}
+    \tikzset{my dc symbol/.style={
+        dc symbol,
+        circuitikz/misc/thickness=3,
+        circuitikz/dc symbol/height=0.1,
+        circuitikz/dc symbol/width=0.2,
+        circuitikz/dc symbol/relative thickness=.5,
+        circuitikz/dc symbol/segments=3
+    }}
+    \node (A) at (0,0) {A}; \node (V) at (1,0) {V};
+    % standard
+    \node [dc symbol, above, circuitikz/misc/thickness=4] at (A.north) {};
+    % tweaked
+    \node [my dc symbol, above] at (V.north) {};
+\end{tikzpicture}
+\end{LTXexample}
+
 \subsection{Multiple wires (buses)}
 
 These are simple drawings to indicate multiple wires.

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4620,6 +4620,8 @@ In the ``plot''-type filter blocks, you can change the appearance of the fake se
 
 Additionally, the \IndexKey{blocks/filter plot/relative thickness} (default \ctikzvalof{blocks/filter plot/relative thickness}) will change the relative thickness (with respect to the class thickness, or \texttt{inner thickness} if set) of the ``frequency response'' sketch line.
 
+Finally, the plots are by default rounded\footnote{This, and the hint for the new filter shapes, were suggested by \href{https://chat.stackexchange.com/transcript/message/68537036\#68537036}{@cis on the TeX-SX chat}.}, but you can choose to have them with sharp edges setting the key \IndexKey{blocks/filter plot/rounding} to \texttt{0} (the default value is \texttt{0.15}).
+
 \begin{LTXexample}[varwidth=true]
     \begin{circuitikz} \draw
         (0,0) to[lowpassp=\qty{1}{\kHz},
@@ -4628,9 +4630,11 @@ Additionally, the \IndexKey{blocks/filter plot/relative thickness} (default \cti
         blocks/filter grid/thickness=1] ++(2,0)
         to[notchp=\qty{50}{\hertz},
         blocks/filter grid/opacity=0,
-        blocks/filter plot/relative thickness=1] ++(2,0);
+        blocks/filter plot/relative thickness=1,
+        blocks/filter plot/rounding=0] ++(2,0);
     \end{circuitikz}
 \end{LTXexample}
+
 
 
 \subsection{Transistors}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -7009,16 +7009,19 @@ Finally, notice that the value of width for the rotary switches is taken from th
 
 \paragraph{Rotary switch customization}
 
-Apart from the basic customization seen above (number of channels, etc.) you can change, as in the cute switches, the shape used by the connection points with the parameter \IndexKey{multipoles/rotary/shape}, and the thickness of the wiper with \IndexKey{multipoles/rotary/thickness}. The optional arrow has thickness equal to the standard bipole thickness \texttt{bipoles/thickness} (default 2).
+Apart from the basic customization seen above (number of channels, etc.) you can change, as in the cute switches, the shape used by the connection points with the parameter \IndexKey{multipoles/rotary/shape}, and the thickness of the wiper with \IndexKey{multipoles/rotary/thickness}; if you specify a negative value here, the wiper is not drawn at all\footnote{Suggested by users \texttt{kabenyuk} and \texttt{cis} on TeX-SX.com; see \href{https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display}{this question\&answer for an application}.}(but the anchors, and the additional arrow if you specify it, are still there).
+The optional arrow has thickness equal to the standard bipole thickness \texttt{bipoles/thickness} (default 2).
 
 \begin{LTXexample}[varwidth=true]
 \begin{circuitikz}
     \ctikzset{multipoles/rotary/thickness=0.5}
-    \draw (0,1.6) node[rotary switch ->, color=blue](S1){};
+    \draw (0,2) node[rotary switch ->, color=blue](S1){};
     \ctikzset{multipoles/rotary/shape=circ}
     \draw (0,0) node[rotary switch ->](S2){};
     \ctikzset{bipoles/thickness=0.5}
-    \draw (0,-1.6) node[rotary switch ->, color=red](S3){};
+    \draw (2,2) node[rotary switch ->, color=red](S3){};
+    \ctikzset{multipoles/rotary/thickness=-1}
+    \draw (2,0) node[rotary switch, color=purple](S4){};
 \end{circuitikz}
 \end{LTXexample}
 

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -3830,19 +3830,19 @@ As shown in the example above, the \texttt{dc symbols} has an additional options
 Additionally, you can change the relative thickness of the bottom line with the key \texttt{dc symbols/relative thickness} (default \texttt{1}).
 
 \begin{LTXexample}[varwidth=true, basicstyle=\small\ttfamily]
-    \begin{tikzpicture}
+    \begin{tikzpicture}[scale=2, transform shape]
     \tikzset{my dc symbol/.style={
         dc symbol,
-        circuitikz/misc/thickness=3,
+        circuitikz/misc/thickness=4,
         circuitikz/dc symbol/height=0.1,
         circuitikz/dc symbol/width=0.2,
         circuitikz/dc symbol/relative thickness=.5,
         circuitikz/dc symbol/segments=3
     }}
     \node (A) at (0,0) {A}; \node (V) at (1,0) {V};
-    % standard
-    \node [dc symbol, above, circuitikz/misc/thickness=4] at (A.north) {};
-    % tweaked
+    % standard and customized
+    \node [dc symbol, above,
+        circuitikz/misc/thickness=4] at (A.north) {};
     \node [my dc symbol, above] at (V.north) {};
 \end{tikzpicture}
 \end{LTXexample}
@@ -4594,19 +4594,23 @@ Moreover, the key \IndexKey{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|)
 \paragraph{Dashing the DC symbol in blocks.}
 The symbol for the DC side can be different across countries,\footnote{Head-up from \href{https://github.com/circuitikz/circuitikz/issues/680}{user \texttt{@dbstf} on GitHub}} with different kind of dashing on the bottom line.
 Moreover, sometimes the dashing is used to convey different meanings (like rectified sinusoidal or stabilized DC).
-You can change the general style for the DC symbol using the key \IndexKey{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \IndexKey{blocks dc in segments} and \IndexKey{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} option overrides these ones.
+You can change the general style for the DC symbol using the key \IndexKey{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \IndexKey{blocks dc in segments} and \IndexKey{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} can have strange interaction with these ones.
 
-\begin{LTXexample}[varwidth=true]
-\begin{tikzpicture}[scale=0.9]
+
+\begin{LTXexample}[varwidth=true, basicstyle=\footnotesize\ttfamily]
+\begin{tikzpicture}[scale=0.8]
     \ctikzset{blocks dc segments=3}
     \draw (0,2) to[sacdc] ++(2,0) to[sdcdc]
         ++(2,0) to[sdcac] ++(2,0);
     \ctikzset{blocks dc segments=1}
-    \draw (0,0) to[sacdc, blocks dc out segments=2]
-        ++(2,0) to[sdcdc, blocks dc in segments=2]
+    \draw[dashed] (0,0) to[sacdc, blocks dc out segments=2]
+        ++(2,0) to[sdcdc, blocks dc in segments=2,
+            inner blocks dashed,
+            dashed blocks pattern={{0.4pt}{0.4pt}}]
         ++(2,0) to[sdcac] ++(2,0);
 \end{tikzpicture}
 \end{LTXexample}
+
 
 \paragraph{Blocks inner drawing.}
 Most of the inner block drawings can be customized, without affecting the external box, with the keys \IndexKey{blocks/inner color} (default \texttt{default}, which means ``don't change color'') and \IndexKey{blocks/inner thickness} (default \texttt{1}; this is relative to the class-specified thickness).

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -4210,6 +4210,8 @@ For example, and audio jack can be drawn like this:
     \circuitdescbip*{bandstop}{bandstop}{}
     \circuitdescbip*{highpass}{highpass}{}
     \circuitdescbip*{lowpass}{lowpass}{}
+    \circuitdescbip*{highpass2}{simplified highpass (with only 2 waves)}{}
+    \circuitdescbip*{lowpass2}{simplified lowpass (with only 2 waves)}{}
     \circuitdescbip*{allpass}{allpass}{}
     \circuitdescbip*{vallpass}{variable allpass\footnotemark}{}
     \footnotetext{This block, as well as \texttt{bgenerator}, \texttt{cgenerator}, \texttt{qgenerator}, \texttt{ngenerator},
@@ -4219,8 +4221,6 @@ For example, and audio jack can be drawn like this:
     \circuitdescbip*{qgenerator}{Crystal generator (use \texttt{t=\dots} to specify text)}{}
     \circuitdescbip*{cgenerator}{Clock generator}{}
     \circuitdescbip*{ngenerator}{Generic generator (use \texttt{t=\dots} to specify text)}{}
-    \circuitdescbip*{highpass2}{simplified highpass (with only 2 waves)}{}
-    \circuitdescbip*{lowpass2}{simplified lowpass (with only 2 waves)}{}
     \circuitdescbip*{adc}{A/D converter}{}
     \circuitdescbip*{dac}{D/A converter}{}
     \circuitdescbip*{dsp}{DSP}{}
@@ -4251,6 +4251,20 @@ For example, and audio jack can be drawn like this:
     \circuitdescbip*{tacdc}{three phases AC/DC converter}{}(ac up in/135/.3, ac mid in/185/.3, ac down in/-135/.3, dc up out/45/.3, dc down out/-35/.3)
     \circuitdescbip*{tdcac}{three phases AC/DC converter}{}(ac up out/45/0.1, ac mid out/-5/.3, ac down out/-45/.1, dc up in/135/.3, dc down in/185/.3)
     \circuitdescbip*{tacac}{three phases AC/DC converter}{}(ac up in/135/.3, ac mid in/185/.3, ac down in/-135/.3, ac up out/45/.3, ac mid out/-5/.3, ac down out/-45/.3)
+\end{groupdesc}
+
+Filters blocks have an alternative, Bode-diagram-like appearance.
+Their names end in \texttt{p}, as a mnemonic for ``plot''.
+By default, they have a ``fake'' semi-logarithmic grid to convey the hint that the diagram is a frequency response one, to separate them from similar drawings as, for example, saturation.
+The grid can be removed or customized, see section~\ref{sec:block-filter-grid-cust}.
+
+\begin{groupdesc}
+    \circuitdescbip*{lowpassp}{lowpass, plot style}{}
+    \circuitdescbip*{highpassp}{highpass, plot style}{}
+    \circuitdescbip*{bandpassp}{bandpass, plot style}{}
+    \circuitdescbip*{bandstopp}{bandstop, plot style}{}
+    \circuitdescbip*{resonantp}{resonant, plot style}{}
+    \circuitdescbip*{notchp}{notch, plot style}{}
 \end{groupdesc}
 
 Blocks to draw TV/radio system schematics, contributed by \href{https://github.com/circuitikz/circuitikz/pull/693}{Dr. Matthias Jung}.
@@ -4573,6 +4587,51 @@ You can change the general style for the DC symbol using the key \IndexKey{block
         ++(2,0) to[sdcac] ++(2,0);
 \end{tikzpicture}
 \end{LTXexample}
+
+\paragraph{Blocks inner drawing.}
+Most of the inner block drawings can be customized, without affecting the external box, with the keys \IndexKey{blocks/inner color} (default \texttt{default}, which means ``don't change color'') and \IndexKey{blocks/inner thickness} (default \texttt{1}; this is relative to the class-specified thickness).
+
+\begin{LTXexample}[varwidth=true]
+\begin{circuitikz} \draw
+  (0,0) to[short,o-] ++(0.3,0)
+  to[lowpass,>, blocks/inner color=red ] ++(2,0)
+  to[lowpassp,>, blocks/inner thickness=4,
+    blocks/filter grid/thickness=0.25] ++(2,0)
+  to[short,-o] ++(0.3,0);
+\end{circuitikz}
+\end{LTXexample}
+
+\paragraph{Block filter grid customization.}\label{sec:block-filter-grid-cust}
+In the ``plot''-type filter blocks, you can change the appearance of the fake semi-logarithmic grid using the following parameters (with \verb!\ctikzset!, under the family \IndexKey{blocks/filter grid/})
+
+\begin{center}
+    \begin{tabular}{>{\ttfamily}l>{\ttfamily}lp{8cm}}
+        \toprule
+     parameter &  default & description  \\
+     \midrule
+     thickness & 0.5 & line thickness, this is relative to the \texttt{inner thickness} setting for the block \\
+     color & default & stroke color: \texttt{default} is the same as the component color (\texttt{inner color} if it's set) \\
+     dash & \{\{0.04cm\}\{0.04cm\}\} & dash pattern: none means solid line, default means keep the global pattern\footnotemark \\
+     opacity & 0.3 & stroke opacity for the grid. Using \texttt{0} will suppress the drawing of the grid completely. \\
+        \bottomrule
+    \end{tabular}
+    \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples. Notice that the dimensions are not exactly \unit{cm}: the length are scaled so that \qty{1}{cm} is really the block width.}
+\end{center}
+
+Additionally, the \IndexKey{blocks/filter plot/relative thickness} (default \ctikzvalof{blocks/filter plot/relative thickness}) will change the relative thickness (with respect to the class thickness, or \texttt{inner thickness} if set) of the ``frequency response'' sketch line.
+
+\begin{LTXexample}[varwidth=true]
+    \begin{circuitikz} \draw
+        (0,0) to[lowpassp=\qty{1}{\kHz},
+        blocks/filter grid/color=red,
+        blocks/filter grid/dash=none,
+        blocks/filter grid/thickness=1] ++(2,0)
+        to[notchp=\qty{50}{\hertz},
+        blocks/filter grid/opacity=0,
+        blocks/filter plot/relative thickness=1] ++(2,0);
+    \end{circuitikz}
+\end{LTXexample}
+
 
 \subsection{Transistors}
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -59,11 +59,16 @@
 \newdimen\pgf@circ@Rlen
 % scaled length for internal use in scalable shapes
 \newdimen\pgf@circ@scaled@Rlen
-\ctikzset{bipoles/length/.code={\pgf@circ@Rlen = #1\pgf@circ@scaled@Rlen=\pgf@circ@Rlen}}
-\pgf@circ@Rlen = 1.4cm
-% by default scale is 1.0
-\pgf@circ@scaled@Rlen=\pgf@circ@Rlen
-% inital thickness
+\ctikzset{%
+  bipoles/length/.code={%
+    \pgf@circ@Rlen = #1\relax
+    % by default scale is 1.0
+    \pgf@circ@scaled@Rlen=\pgf@circ@Rlen
+    \ctikzsetvalof{bipoles/length}{#1}%
+  }%
+  ,bipoles/length=1.4cm%
+}
+% initial thickness
 \newdimen \pgfstartlinewidth
 %%>>>
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -262,6 +262,22 @@
 %
 \def\ctikz@hook@start@draw@default{\pgf@circ@reset@arrows@rounded}
 %
+% we can't use dash pattern (not easily) to draw a fixed number of dashes.
+% See https://github.com/circuitikz/circuitikz/issues/897
+%
+\def\pgf@circ@do@n@hdashes#1#2#3#4{%
+    % this does the following: draw #1 dashes, each of length #2
+    % separated by a blank space of the same length
+    % starting from (#3, #4) and going horizontal
+    \pgf@circ@count@a=0 %
+    \pgfmathloop%
+    \ifnum\pgf@circ@count@a<#1 %
+        \pgfpathmoveto{\pgfpointadd{\pgfpoint{#3}{#4}}{\pgfpoint{(2*\pgf@circ@count@a)*(#2)}{0pt}}}
+        \pgfpathlineto{\pgfpointadd{\pgfpoint{#3}{#4}}{\pgfpoint{(2*\pgf@circ@count@a+1)*(#2)}{0pt}}}
+        \advance\pgf@circ@count@a by 1\relax%
+    \repeatpgfmathloop
+}
+%
 %
 %>>>
 

--- a/tex/pgfcirc.defines.tex
+++ b/tex/pgfcirc.defines.tex
@@ -559,6 +559,16 @@
         }{}
     \fi
 }
+% set the color for a subset of the shape, following keys #1/color
+% The key must exist, and check for default (no change)
+\def\pgf@circ@subset@color#1{%
+    % You *must* be sure that this is called inside a \pgfscope!
+    \edef\@@default{default}
+    \edef\@@tmp{\ctikzvalof{#1}}
+    \ifx\@@tmp\@@default\else
+        \pgfsetstrokecolor{\@@tmp}
+    \fi
+}
 
 % set the color and dash pattern for a subset of the shape, following keys #1/color
 % and #1/dash. The keys must exist, and check for none or default for both

--- a/tex/pgfcircmultipoles.tex
+++ b/tex/pgfcircmultipoles.tex
@@ -811,13 +811,15 @@
         \pgf@circ@res@left = -\width
 
         \pgfscope %wiper
-        % This is the radius of the "ocirc" shape (see pgfcircshapes.tex)
-        \pgf@circ@res@temp=\radius\relax
-        \pgf@circ@res@temp=\ctikzvalof{multipoles/rotary/thickness}\pgf@circ@res@temp
-        \pgfsetlinewidth{2\pgf@circ@res@temp}
-        \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
-        \pgfpathlineto{\pgfpointadd{\pgfpoint{\pgf@circ@res@left}{0pt}}{\pgfpointpolar{\wiper}{2\pgf@circ@res@right}}}
-        \pgfsetroundcap\pgfusepath{draw}
+            % This is the radius of the "ocirc" shape (see pgfcircshapes.tex)
+            \pgf@circ@res@temp=\radius\relax
+            \pgf@circ@res@temp=\ctikzvalof{multipoles/rotary/thickness}\pgf@circ@res@temp
+            \ifdim\pgf@circ@res@temp<0pt \else
+                \pgfsetlinewidth{2\pgf@circ@res@temp}
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{0pt}}
+                \pgfpathlineto{\pgfpointadd{\pgfpoint{\pgf@circ@res@left}{0pt}}{\pgfpointpolar{\wiper}{2\pgf@circ@res@right}}}
+                \pgfsetroundcap\pgfusepath{draw}
+            \fi
         \endpgfscope
 
         \ifpgf@circ@rotaryarrow

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -662,6 +662,7 @@
     \pgfcirc@twoport@draw@logax
     \edef\@@tmp{\ctikzvalof{blocks/filter plot/relative thickness}}
     \pgfsetlinewidth{\@@tmp\pgflinewidth}
+    \pgfsetcornersarced{\pgfpoint{.15\pgf@circ@res@step}{.15\pgf@circ@res@step}}
 }
 % draw a fake log-log grid for scale
 \def\pgfcirc@twoport@draw@logax{%
@@ -2054,9 +2055,9 @@
 {
     \pgfcirc@setup@plot@filters
     \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{-0.1\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{ 0.1\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.15\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{0.7\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.15\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
     \pgfusepath{draw}
 }
@@ -2070,9 +2071,9 @@
 {
     \pgfcirc@setup@plot@filters
     \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{-0.1\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{ 0.1\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.15\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{-0.7\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.15\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
     \pgfusepath{draw}
 }

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -657,12 +657,14 @@
 \ctikzset{blocks/filter grid/thickness/.initial=0.5}
 \ctikzset{blocks/filter grid/opacity/.initial=0.3}
 \ctikzset{blocks/filter plot/relative thickness/.initial=2}
+\ctikzset{blocks/filter plot/rounding/.initial=0.15}
 % set up plot-type drawing
 \def\pgfcirc@setup@plot@filters{%
     \pgfcirc@twoport@draw@logax
     \edef\@@tmp{\ctikzvalof{blocks/filter plot/relative thickness}}
     \pgfsetlinewidth{\@@tmp\pgflinewidth}
-    \pgfsetcornersarced{\pgfpoint{.15\pgf@circ@res@step}{.15\pgf@circ@res@step}}
+    \edef\@@tmp{\ctikzvalof{blocks/filter plot/rounding}}
+    \pgfsetcornersarced{\pgfpoint{\@@tmp\pgf@circ@res@step}{\@@tmp\pgf@circ@res@step}}
 }
 % draw a fake log-log grid for scale
 \def\pgfcirc@twoport@draw@logax{%

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -643,7 +643,83 @@
 \ctikzset{bipoles/tacdc/width/.initial=.7}
 \ctikzset{bipoles/tdcac/width/.initial=.7}
 \ctikzset{quadpoles/gridnode/width/.initial=.7} %not sure if quadpole?
-
+% plot-type filters
+\ctikzset{bipoles/lowpassp/width/.initial=.7}
+\ctikzset{bipoles/highpassp/width/.initial=.7}
+\ctikzset{bipoles/bandpassp/width/.initial=.7}
+\ctikzset{bipoles/bandstopp/width/.initial=.7}
+\ctikzset{bipoles/resonantp/width/.initial=.7}
+\ctikzset{bipoles/notchp/width/.initial=.7}
+% plot-type filters grid options
+\ctikzset{blocks/filter grid/.is family}
+\ctikzset{blocks/filter grid/dash/.initial={{0.04cm}{0.04cm}}}
+\ctikzset{blocks/filter grid/color/.initial=default}
+\ctikzset{blocks/filter grid/thickness/.initial=0.5}
+\ctikzset{blocks/filter grid/opacity/.initial=0.3}
+\ctikzset{blocks/filter plot/relative thickness/.initial=2}
+% set up plot-type drawing
+\def\pgfcirc@setup@plot@filters{%
+    \pgfcirc@twoport@draw@logax
+    \edef\@@tmp{\ctikzvalof{blocks/filter plot/relative thickness}}
+    \pgfsetlinewidth{\@@tmp\pgflinewidth}
+}
+% draw a fake log-log grid for scale
+\def\pgfcirc@twoport@draw@logax{%
+    \pgfscope
+        \edef\@@opacity{\ctikzvalof{blocks/filter grid/opacity}}
+        \ifdim\@@opacity pt>0pt
+            \pgfmathsetmacro{\@@scale}{\pgf@circ@res@step/1cm}
+            \pgftransformxscale{\@@scale}
+            \pgftransformyscale{\@@scale}
+            % horizontal lin
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{-0.8cm}}
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.4cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{-0.4cm}}
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{-0cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{-0cm}}
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{0.4cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{0.4cm}}
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{0.8cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{0.8cm}}
+            % horizonatal log
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.8cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.8cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.3cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.3cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.1cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.1cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{-0cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.5cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{0.5cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.7cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{0.7cm}}
+            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.8cm}}
+            % \pgfpathlineto{\pgfpoint{0.8cm}{0.8cm}}
+            % vertical
+            \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{-0.8cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{-0.3cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{-0.3cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{-0.1cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{-0.1cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{-0cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{-0cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{0.5cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{0.5cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{0.7cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{0.7cm}{0.8cm}}
+            \pgfpathmoveto{\pgfpoint{0.8cm}{-0.8cm}}
+            \pgfpathlineto{\pgfpoint{0.8cm}{0.8cm}}
+            %
+            \pgf@circ@subset@thickness{blocks/filter grid}
+            \pgf@circ@subset@color@dash{blocks/filter grid}
+            \pgfsetstrokeopacity{\@@opacity}
+            \pgfusepath{draw}
+        \fi
+    \endpgfscope
+}
 %>>>
 
 %% Node shapes definition for path-style block diagrams%<<<
@@ -719,6 +795,8 @@
     \pgftext[center,x=0,y=0,]{\tiny\ttfamily\pgf@circ@direction > \@@rotation}
 }
 %
+\ctikzset{blocks/inner thickness/.initial=1}
+\ctikzset{blocks/inner color/.initial=default}
 \def\pgfcirc@twoport@setup#1{%
     \pgf@circ@res@step = #1\pgf@circ@scaled@Rlen%6 is the real width parameter
     \divide \pgf@circ@res@step by 2
@@ -787,6 +865,9 @@
         \ifpgf@circuit@full@dashed\else\pgfsetdash{}{0pt}\fi
         \pgf@circ@inputarrow
         \pfgcirc@twoport@rotate@inner@symbol
+        % set inner symbol options
+        \pgf@circ@subset@color{blocks/inner color}
+        \pgf@circ@set@relative@thickness{inner thickness}
         #7
     }
 }
@@ -808,6 +889,9 @@
         % draw solid line for inner symbol if no box is drawn and not fully dashed
         \ifpgf@circuit@full@dashed\else\pgfsetdash{}{0pt}\fi
         \pgf@circ@inputarrow
+        % set inner symbol options
+        \pgf@circ@subset@color{blocks/inner color}
+        \pgf@circ@set@relative@thickness{inner thickness}
         #7
     }
 }
@@ -1900,6 +1984,98 @@
 
 \pgfcirc@activate@bipole@simple{l}{fiber}
 %
+% plot-type filters
+%
+%% lowpassg filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/lowpassp/width}}
+{lowpassp}
+{\ctikzvalof{bipoles/lowpassp/width}}
+{\ctikzvalof{bipoles/lowpassp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+%% highpassg filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/highpassp/width}}
+{highpassp}
+{\ctikzvalof{bipoles/highpassp/width}}
+{\ctikzvalof{bipoles/highpassp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+%% bandpassg filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/bandpassp/width}}
+{bandpassp}
+{\ctikzvalof{bipoles/bandpassp/width}}
+{\ctikzvalof{bipoles/bandpassp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.4\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.4\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+%% bandstopg filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/bandstopp/width}}
+{bandstopp}
+{\ctikzvalof{bipoles/bandstopp/width}}
+{\ctikzvalof{bipoles/bandstopp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.4\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.4\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+%% notch filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/resonantp/width}}
+{resonantp}
+{\ctikzvalof{bipoles/resonantp/width}}
+{\ctikzvalof{bipoles/resonantp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.1\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.1\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
+%% notch filter
+\pgfcirc@define@twoports{blocks}
+{}
+{\ctikzvalof{bipoles/notchp/width}}
+{notchp}
+{\ctikzvalof{bipoles/notchp/width}}
+{\ctikzvalof{bipoles/notchp/width}}
+{
+    \pgfcirc@setup@plot@filters
+    \pgfpathmoveto{\pgfpoint{-0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{-0.1\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{0\pgf@circ@res@step}{-0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.1\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfpathlineto{\pgfpoint{ 0.7\pgf@circ@res@step}{0.6\pgf@circ@res@step}}
+    \pgfusepath{draw}
+}
 % %>>>
 
 %% Path definitions for Blocks%<<<
@@ -1952,6 +2128,12 @@
 \pgfcirc@activate@bipole@simple{l}{tacdc}
 \pgfcirc@activate@bipole@simple{l}{tdcac}
 \pgfcirc@activate@bipole@simple{l}{tacac}
+\pgfcirc@activate@bipole@simple{l}{lowpassp}
+\pgfcirc@activate@bipole@simple{l}{highpassp}
+\pgfcirc@activate@bipole@simple{l}{bandpassp}
+\pgfcirc@activate@bipole@simple{l}{bandstopp}
+\pgfcirc@activate@bipole@simple{l}{notchp}
+\pgfcirc@activate@bipole@simple{l}{resonantp}
 % %>>>
 
 %% Node shapes for  Block elements %<<<

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -683,21 +683,6 @@
             \pgfpathlineto{\pgfpoint{0.8cm}{0.4cm}}
             \pgfpathmoveto{\pgfpoint{-0.8cm}{0.8cm}}
             \pgfpathlineto{\pgfpoint{0.8cm}{0.8cm}}
-            % horizonatal log
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.8cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.8cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.3cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.3cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.1cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{-0.1cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{-0cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{-0cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.5cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{0.5cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.7cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{0.7cm}}
-            % \pgfpathmoveto{\pgfpoint{-0.8cm}{0.8cm}}
-            % \pgfpathlineto{\pgfpoint{0.8cm}{0.8cm}}
             % vertical
             \pgfpathmoveto{\pgfpoint{-0.8cm}{-0.8cm}}
             \pgfpathlineto{\pgfpoint{-0.8cm}{0.8cm}}

--- a/tex/pgfcircquadpoles.tex
+++ b/tex/pgfcircquadpoles.tex
@@ -1554,21 +1554,27 @@
 \def\pgf@circ@twoport@converter@dc#1#2{%
     \pgfscope
     \pgftransformshift{\pgfpoint{#1\pgf@circ@res@step}{#2\pgf@circ@res@step}}
+    % upper line, always continuos
     \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{0.125\pgf@circ@res@step}}
     \pgfusepath{draw}
-    \ifpgf@circuit@full@dashed\else % do not apply the specific dash if fully dashing
-        \edef\@@up{\ctikzvalof{blocks dc in segments}}
-        \edef\@@down{\ctikzvalof{blocks dc out segments}}
-        \ifdim\dimexpr#1\pgf@circ@res@step\relax<0pt
-            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@up-2)}
-        \else
-            \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@down-2)}
-        \fi
-        \pgfsetdash{{\pgf@circ@res@other}{\pgf@circ@res@other}}{0pt}
+    % lower line, may be dashed
+    % let us dash everything is needed (this is a change from before)
+    \ifdim\dimexpr#1\pgf@circ@res@step\relax<0pt
+        % this is the upper side
+        \edef\@@tmp{\ctikzvalof{blocks dc in segments}}
+    \else
+        % this is the lower side
+        \edef\@@tmp{\ctikzvalof{blocks dc out segments}}
     \fi
-    \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
-    \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+        \pgfmathsetlength{\pgf@circ@res@other}{\pgf@circ@res@step/(4*\@@tmp-2)}
+    \ifnum\@@tmp>1
+        % we can't use dash here; the dash length is not scaled
+        \pgf@circ@do@n@hdashes{\@@tmp}{\pgf@circ@res@other}{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}
+    \else
+        \pgfpathmoveto{\pgfpoint{-0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+        \pgfpathlineto{\pgfpoint{0.25\pgf@circ@res@step}{-0.125\pgf@circ@res@step}}
+    \fi
     \pgfusepath{draw}
     \endpgfscope
 }

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -919,6 +919,7 @@
     \anchor{text}{\textanchor}
     \pgfcirc@northeast@symmetric@geoanchors
     \pgf@circ@draw@component{
+        \pgfstartlinewidth=\pgflinewidth
         \pgfscope
             \pgf@circ@setcolor
             \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}
@@ -967,6 +968,7 @@
     \anchor{text}{\textanchor}
     \pgfcirc@northeast@symmetric@geoanchors
     \pgf@circ@draw@component{
+        \pgfstartlinewidth=\pgflinewidth
         \pgfscope
             \pgf@circ@setcolor
             \pgf@circ@setlinewidth{bipoles}{\pgfstartlinewidth}

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -899,6 +899,7 @@
 \ctikzset{dc symbol/segments/.initial=2}
 \ctikzset{dc symbol/text offset/.initial=6pt}
 \tikzset{dc symbol segments/.code={\ctikzset{dc symbol/segments=#1}}}
+\ctikzset{dc symbol/relative thickness/.initial=1}
 \pgfdeclareshape{dc symbol}{
     \savedmacro{\ctikzclass}{\edef\ctikzclass{misc}}
     \saveddimen{\scaledRlen}{\pgfmathsetlength{\pgf@x}{\ctikzvalof{misc/scale}\pgf@circ@Rlen}}
@@ -932,6 +933,8 @@
             \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
             \pgfusepath{draw}
             % lower line
+            \edef\@@tmp{\ctikzvalof{dc symbol/relative thickness}}
+            \pgfsetlinewidth{\@@tmp\pgflinewidth}
             \edef\@@dashes{\ctikzvalof{dc symbol/segments}}
             \ifnum\@@dashes>1
                 \pgfmathsetlength{\pgf@circ@res@other}{2*\pgf@circ@res@right/(2*(\@@dashes-1)+1)}

--- a/tex/pgfcircshapes.tex
+++ b/tex/pgfcircshapes.tex
@@ -938,10 +938,11 @@
             \edef\@@dashes{\ctikzvalof{dc symbol/segments}}
             \ifnum\@@dashes>1
                 \pgfmathsetlength{\pgf@circ@res@other}{2*\pgf@circ@res@right/(2*(\@@dashes-1)+1)}
-                \pgfsetdash{{\pgf@circ@res@other}{\pgf@circ@res@other}}{0pt}
+                \pgf@circ@do@n@hdashes{\@@dashes}{\pgf@circ@res@other}{\pgf@circ@res@left}{\pgf@circ@res@down}
+            \else
+                \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
+                \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
             \fi
-            \pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@down}}
-            \pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
             \pgfusepath{draw}
         \endpgfscope
     }


### PR DESCRIPTION
I have a few suggestions and ideas for the manual of your grandiose package; perhaps you'll find them useful.

___
**A.** Provide a table-overview of all subsequent electrical symbols (maybe with their names) in each chapter or section (hyperlinked).
→ _This allows the user to quickly and easily access the component they need._

Arbitrary example:
<img width="1026" height="354" alt="image" src="https://github.com/user-attachments/assets/17890507-a457-465c-bf16-720605429ddf" />
___
**B.** I (very) often copy test examples from the manual.
The line numbering should be omitted from your example codes, as it is copied along with the text and then has to be removed manually.

Example:
<img width="864" height="170" alt="image" src="https://github.com/user-attachments/assets/e4a6f8d7-476b-4494-b1d4-0ff2a15b5103" />

→ _Particularly user-friendly in this context is the `pgfplots`-manual (or the `pgfplotstables`-manual or the `TikZ`-manual or...) from which you can easily copy example code:_
<img width="644" height="253" alt="image" src="https://github.com/user-attachments/assets/ea311bd0-d32d-4e79-b80c-d2fe289d13cd" />

→ I would consider adopting this "code-preview-style" from the `Tikz`- or `pgfplots`-manual (yellow background: image, blue background: code [without line numbers]).
There are even ready-made packages for this style; I myself would probably use `tcolorbox.sty`, but you're likely more familiar with that.

Finally, this would also place `circuitikz.sty` alongside `pgfplots.sty`, `tikz.sty`, `pgfplotstables.sty`, etc. – where it belongs. :()

___
**C.** I would list for _each_ electrical symbol all the keys, which  are possible for that electrical symbol.
`circuitikz/tripoles/op amp/height=1.2`
`circuitikz/tripoles/op amp/width =1.5`
`.... and so on .....`

→ _This will likely make the manual noticeably larger, but it will make it much more user-friendly._
I often have to search for keys from `pgfcircbipoles.tex`, etc. This is not a standard package usage.
___

All the best and much success!