### PR TITLE
Redo lwarp with enverb

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -8988,7 +8988,8 @@ Look at the following example, which is easily put into a macro.
         node[right, font=\tiny]{CLK} -- ++(-0.1,-0.1);
     \draw (C.n) -- ++(0,1) node[vcc]{};
     \draw (C.s) -- ++(0,-1) node[ground]{};
-\end{circuitikz}\end{LTXexample}
+\end{circuitikz}
+\end{LTXexample}
 
 \subsection{Seven segment displays}
 \label{sec:seven-segment-displays}
@@ -10510,7 +10511,7 @@ There is little sense in using the \texttt{vif queue add} key explicitly; it is 
 
 For example, let's suppose you like the \texttt{raised} voltage notation, but you want the plus and minus signs at a fixed distance from the label, independently on the size of the branch where the component is, and moreover you want to be able to change the color or the style of the signs. We can setup the voltage like this:
 
-\begin{lstlisting}[varwidth=true]
+\begin{lstlisting}
 %% The voltage label (the text) will be managed normally by v...={}
 %% We need just one parameter to specify the coloa/styler of the signs; we
 %% set the other argument to nothing.
@@ -10552,7 +10553,7 @@ For example, let's suppose you like the \texttt{raised} voltage notation, but yo
 
 If you have an old \LaTeX{} or are using \ConTeXt, you must add the \texttt{use auto vif} to the options of the environment; the option will not have any negative effect if it is not needed.
 
-\begin{lstlisting}[varwidth=true]
+\begin{lstlisting}
 \begin{tikzpicture}[use auto vif]
     ... as before
 \end{tikzpicture}
@@ -10568,7 +10569,7 @@ Suppose now we want to change the current indication so that we can typeset the 
     #4] at (#1-Ipos) {{\boldmath #2}}; %the double {} are needed!!!
 }
 
-\begin{lstlisting}[varwidth=true]
+\begin{lstlisting}
 %% arguments: label, style for the arrow, style for the label
 \ctikzset{my i/.style n args  = {3}{vif queue add={docurrent}{#1}{#2}{#3}}}
 \newcommand{\docurrent}[4]{
@@ -10602,7 +10603,7 @@ Suppose now we want to change the current indication so that we can typeset the 
 Sometimes, the need of using the syntax \texttt{v, my v=\dots} can result tedious; unfortunately, it is not possible to add the \texttt{v} to the key \texttt{my v} because it will reset the direction/position of the key. To avoid this problem, you can use the new command
 \verb!\!\IndexKey{ctikzactivatevoltagedirections} (and their sibling \verb!\!\IndexKey{ctikzactivatecurrentdirections} and \verb!\!\IndexKey{ctikzactivateflowdirections}) which will create the full set of personalized voltage (or current or flow) commands with the appended directions. For example, this is how we can reimplement the ``European arrow with signs'' shown in the previous section:
 
-\begin{lstlisting}[varwidth=true]
+\begin{lstlisting}
 \newcommand\eurVPM[4]{% node, label, two ignored arguments
     \draw [thin, -{Stealth[width=4pt]}, shorten >=5pt, shorten <=5pt]
     (#1-Vfrom) node[font=\tiny]{$\vphantom{+}-$}
@@ -10647,7 +10648,7 @@ You can use this trick even with styles with more than one argument, but then yo
 \ctikzset{vpms/.style 2 args={european voltages, v, vif queue add={eurVPMstyled}{#1}{#2}{}}}
 \ctikzactivatevoltagedirections{vpms}%
 
-\begin{lstlisting}[varwidth=true]
+\begin{lstlisting}
 \newcommand\eurVPMstyled[4]{% node, label, arrow style, one ignored arguments
     \draw [thin, -{Stealth[width=4pt]}, shorten >=5pt, shorten <=5pt, #3]
     (#1-Vfrom) node[font=\tiny]{$\vphantom{+}-$}

--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -155,7 +155,7 @@ This package is author-maintained. Permission is granted to copy, distribute and
 	\bottomrule
 \end{tabular}
 \end{table}
-\footnotetext{\ConTeXt\ support was added mostly thanks to Mojca Miklavec and Aditya Mahajan.\textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine (March 2023), there can be problems to compile \TikZ{} which some version; in May 2023 the problem has been fixed. Please check \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} for details.}
+\footnotetext{\ConTeXt\ support was added mostly thanks to Mojca Miklavec and Aditya Mahajan. \textbf{Please notice} that since \ConTeXt{} switched to the new \texttt{lmtx} engine (March 2023), there can be problems to compile \TikZ{} with some version; in May 2023 the problem has been fixed. Please check \href{https://github.com/circuitikz/circuitikz/issues/706}{this issue} for details.}
 
 
 \noindent \TikZ\ will be automatically loaded; additionally, the \TikZ{} libraries \texttt{calc}, \texttt{arrows.meta}, \texttt{bending}, and \texttt{fpu} are loaded (the last one is used only on demand).

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -15,8 +15,7 @@
 \RequirePackage{ifthen}
 \RequirePackage{iftex}
 \RequirePackage{etoolbox}% easier lwarp support
-\RequirePackage{xparse}
-\RequirePackage{showexpl}
+\RequirePackage{listings}
 \RequirePackage{ragged2e}
 \RequirePackage{textcomp}
 \RequirePackage{booktabs}
@@ -32,20 +31,116 @@
 \usetikzlibrary{calc, fit, decorations, decorations.pathmorphing, tikzmark}
 \RequirePackage{upgreek}
 %
-% Thanks to Ulrike Fischer https://tex.stackexchange.com/a/57160/38080
-% make the listing line number invisible to copy and paste
-% it seems that sometimes it works, sometimes no!
+% Example definitions using `enverb`
 %
-\RequirePackage{accsupp}
-\newcommand{\emptyaccsupp}[1]{\BeginAccSupp{ActualText={}}#1\EndAccSupp{}}%
-%
-% The following trick is used to silence showexpl a bit, so that the
-% logs are readable... Also, make the boxes cyan as the code background
-%
-\let\SX@Info=\relax % silence showexpl a bit...
-\renewcommand\ResultBox{\fcolorbox{cyan}{white}}
-\setlength\ResultBoxSep{6pt}    % like \fboxsep
-\setlength\ResultBoxRule{0.8pt} % like \fboxrule
+\RequirePackage{enverb}
+\newcommand*\ctikz@ex@lstopts{} % collect options meant for lstlisting
+\newdimen\ctikz@ex@width % width available to the code
+\newsavebox\ctikz@ex@box % temporary box register
+\ekvdefinekeys{ctikz/examples}
+  {
+    % like showexpl but fewer choices
+     choice-store pos       = \ctikz@ex@pos{t,b,l}
+    ,initial      pos       = l
+    ,dimen        hsep      = \ctikz@ex@hsep
+    ,initial      hsep      = 1.5\columnsep
+    ,dimen        vsep      = \ctikz@ex@vsep
+    ,initial      vsep      = \bigskipamount
+    ,dimen        aboveskip = \ctikz@ex@aboveskip
+    ,initial      aboveskip = \medskipamount
+    ,dimen        belowskip = \ctikz@ex@belowskip
+    ,initial      belowskip = \medskipamount
+    % is only used for pos=t, for pos=l we always use variable width
+    ,boolTF       varwidth  = \ctikz@ex@vwidthTF
+    % handle varwidth=t
+    ,choice       varwidth  = { t = \let\ctikz@ex@vwidthTF\@firstoftwo }
+    ,boolTF       only code = \ctikz@ex@onlycodeTF
+    % collect unknown keys for lstlisting
+    ,unknown      code      = \appto\ctikz@ex@lstopts{,#1={#2}}
+    ,unknown      noval     = \appto\ctikz@ex@lstopts{,#1}
+  }
+% print the result of the collected code
+\newcommand*\ctikz@ex@printresult
+  {%
+    \ctikz@ex@vwidthTF
+      {\ctikz@ex@fbox{\enverbExecute}}%
+      {%
+        \if\ctikz@ex@pos l
+          \ctikz@ex@fbox{\enverbExecute}%
+        \else
+          \ctikz@ex@fbox
+            {\begin{minipage}{\linewidth}\enverbExecute\end{minipage}}%
+        \fi
+      }%
+  }
+\newcommand*\ctikz@ex@vcenter{\raisebox{.5\dimexpr\depth-\height\relax}}
+% output a vcentered framed box for the results
+% additionally the output (together with the framed box) will be in the box
+% register \ctikz@ex@box
+\newcommand*\ctikz@ex@fbox[1]
+  {%
+    \sbox\ctikz@ex@box
+      {%
+        \fboxsep=6pt
+        \fboxrule=0.8pt
+        \advance\linewidth-2\dimexpr\fboxsep+\fboxrule\relax
+        \fcolorbox{cyan}{white}{\ignorespaces#1\unskip}%
+      }%
+    $\vcenter{\copy\ctikz@ex@box}$% vcenter matches minipage [c]
+  }
+% output vcentered code listing
+\newcommand*\ctikz@ex@printcode
+  {%
+    \parbox[c]{\ctikz@ex@width}%
+      {%
+        \ExpandArgs{ne}\enverbListing{lstlisting}%
+          {[%
+             style=expl-code
+            ,aboveskip=6pt% we don't want skips but need to compensate listings
+            ,belowskip=0pt%
+            \unexpanded\expandafter{\ctikz@ex@lstopts}%
+          ]}%
+      }%
+  }
+\newenvironment{LTXexample}
+  {\enverb{key-set=ctikz/examples, oarg-not-enverb, more-ignore=0}}
+  {%
+    \par
+    \vskip\ctikz@ex@aboveskip
+    \noindent
+    \ctikz@ex@width=\linewidth
+    \ctikz@ex@onlycodeTF
+      {}%
+      {%
+        \if\ctikz@ex@pos b
+        \else
+          \ctikz@ex@printresult
+          \if\ctikz@ex@pos t
+            \par
+            \vskip\ctikz@ex@vsep
+            \noindent
+          \else
+            \kern\ctikz@ex@hsep
+            \advance\ctikz@ex@width-\wd\ctikz@ex@box
+            \advance\ctikz@ex@width-\ctikz@ex@hsep
+          \fi
+        \fi
+      }%
+    \ctikz@ex@printcode
+    \ctikz@ex@onlycodeTF
+      {}%
+      {%
+        \if\ctikz@ex@pos b
+          \par
+          \vskip\ctikz@ex@vsep
+          \noindent
+          \ctikz@ex@printresult
+        \fi
+      }%
+    \par
+    \vskip\ctikz@ex@belowskip
+    \@endparenv
+  }
 %
 % --- Style for the code part  ---
 % cyan block, no numbers
@@ -67,19 +162,7 @@
   aboveskip=\bigskipamount,
   belowskip=\bigskipamount,
 }
-% --- Style for the example output part  ---
-% ltxexample uses rframe=<...> for the *result* frame
-\lstset{
-  pos=l,
-  width=-99pt,
-  overhang=0pt,
-  hsep=2\columnsep,
-  vsep=\bigskipamount,
-  rframe=single,                % <- frame around the *result*
-}
-
-% Tell showexpl/LTXexample which settings to use for the code listing
-\lstset{explpreset={style=expl-code},style=expl-code}
+\lstset{style=expl-code}
 
 
 \newcommand{\email}[1]{\href{mailto:#1}{#1}}

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -50,7 +50,7 @@
     ,initial      aboveskip = \medskipamount
     ,dimen        belowskip = \ctikz@ex@belowskip
     ,initial      belowskip = \medskipamount
-    % is only used for pos=t, for pos=l we always use variable width
+    % is only used for pos=t or pos=b, for pos=l we always use variable width
     ,boolTF       varwidth  = \ctikz@ex@vwidthTF
     % handle varwidth=t
     ,choice       varwidth  = { t = \let\ctikz@ex@vwidthTF\@firstoftwo }


### PR DESCRIPTION
This here mostly recreates `showexpl` using `enverb`. I hope that this results in more flexibility to support `lwarp` without changing the document.

NB: This speeds up compilation (for me compiling only the first 20 pages was 3 seconds faster, the entire manual 2 minutes).