### PR TITLE
Document enverb code

### DIFF
--- a/doc/circuitikzmanual.tex
+++ b/doc/circuitikzmanual.tex
@@ -160,9 +160,9 @@ This package is author-maintained. Permission is granted to copy, distribute and
 
 \noindent Circui\TikZ\ commands are just \TikZ\ commands, so a minimum usage example would be:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikz \draw (0,0) to[R=$R_1$] (2,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 There is really no support for Plain TeX --- the maintainers are willing to consider patches if somebody is interested.
 
@@ -239,7 +239,7 @@ Also, notice that several components will interact in a funny way with global pa
 Arrows with \texttt{to[]} components don't work, anyway, so basically avoid this situation.
 In some cases, also the engine you are using (as \texttt{pdflatex}, \texttt{xelatex}, and so on) can impact coloring in corner cases (or even not so in the corner, like in \href{https://tex.stackexchange.com/q/709273/38080}{american-style voltage source signs}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,3) to[R] ++(3,0) node[npn, anchor=B]{};
     % arrows will not work and give strange results
@@ -248,7 +248,7 @@ In some cases, also the engine you are using (as \texttt{pdflatex}, \texttt{xela
     \draw[shorten <=10pt] (0,0) to[R] ++(3,0)
          node[npn, anchor=B]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Lastly, voltage styles interacts in strange ways with general (such as \IndexKey{american}, \IndexKey{european} style), in the sense that sometimes the order in which you enact them is important. That should be arguably fixed, but it will change (read break) a lot of existing code, so it'll stay;  more information and workarounds in section~\ref{sec:mixing-voltage-styles}.
 
@@ -258,26 +258,26 @@ As a final notice, if you want to use the \texttt{externalize} library, do not u
 
 Sometimes, when using fractional scaling factors and big values for the coordinates, the basic layer inaccuracies from \TeX{} can bite you, producing results like the following one:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.2, transform shape,
     ]
     \draw (60,1) to [battery2, v_=$V_{cc}$, name=B] ++(0,2);
     \node[draw,red,circle,inner sep=4pt] at(B.left) {};
     \node[draw,red,circle,inner sep=4pt] at(B.right) {};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 A general solution for this problem is difficult to find; probably the best approach is to use a \verb|scalebox| command to scale the circuit instead of relying on internal scaling.
 
 Nevertheless,  \href{https://tex.stackexchange.com/a/529159/38080}{Schrödinger's cat} found a solution which has been ported to \Circuitikz: you can use the  key \IndexKey[fpu]{use fpu reciprocal} which will patch a standard low-level math routine with a more precise one.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.2, transform shape,
     use fpu reciprocal,
     ]
 \draw (60,1) to [battery2, v_=$V_{cc}$] ++(0,2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \texttt{use fpu reciprocal} key seems to have no side effects, but given that it is patching an internal interface of \TikZ{} it can break any time, so it is advisable to use it only if and when needed.
 
@@ -382,13 +382,13 @@ There are arguably way too many options in \Circuitikz, as you can see in the fo
 
 The standard options are set by historical reason, and reflect the preferences of the author that introduced them. For example you get this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R=2<\ohm>, i=?, v=84<\volt>] (2,0) --
     (2,2) to[V<=84<\volt>] (0,2)
     -- (0,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Feel free to load the package with your own cultural options:
 
@@ -400,14 +400,14 @@ Feel free to load the package with your own cultural options:
     \end{tabular}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     [circuitikz/voltage=american, circuitikz/resistor=american] % line not printed
     \draw (0,0) to[R=2<\ohm>, i=?, v=84<\volt>] (2,0) --
     (2,2) to[V<=84<\volt>] (0,2)
     -- (0,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \textbf{However}, most of the global package options are not available in \ConTeXt; in that case you can always use the appropriate \verb|\tikzset{}| or \verb|\IndexKey{}| command after loading the package.
 
@@ -504,27 +504,27 @@ The electrical components can be divided in two main categories: the ones that a
 
 Let's start with the first type of component, and build a basic mesh:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) to[isource] (0,3) -- (2,3)
     to[R] (2,0) -- (0,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The symbol for the current source might surprise some; this is actually the european-style symbol, and the type of symbol chosen reflects the default options of the package (see section~\ref{sec:package-options}). Let's change the style for now (the author of the tutorial, Romano, is European --- but he has always used American-style circuits, so\dots); and while we're at it, let's add the other branch and some labels.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[isource, l=$I_0$] (0,3) -- (2,3)
     to[R=$R_1$] (2,0) -- (0,0);
     \draw (2,3) -- (4,3) to[R=$R_2$]
           (4,0) -- (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use a single path or multiple paths when drawing your circuit, it's just a question of style (but be aware that closing paths perfectly could be non-trivial, see section~\ref{sec:line-joins}), and you can use standard \TikZ\ lines (\verb|--|, \verb+|-+ or similar) for the wires. Nonetheless, sometime using the \Circuitikz{} specific \IndexKey{short} component for the wires can be useful, because then we can add labels and poles to them, as for example in the following circuit, where we add a current (with the key \texttt{i=...}, see section~\ref{sec:currents}) and a connection dot (with the special shortcut \texttt{-*} which adds a \IndexKey{circ} node at the end of the connection, see sections~\ref{sec:terminals} and~\ref{sec:bipole-nodes}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[isource, l=$I_0$] (0,3)
     to[short, -*, i=$I_0$] (2,3)
@@ -533,11 +533,11 @@ You can use a single path or multiple paths when drawing your circuit, it's just
     to[R=$R_2$, i=$i_2$]
     (4,0) to[short, -*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 One of the problems with this circuit is that we would like to have the current labels in a different position, such as for example on the upper side of the resistors, so that Kirchhoff's Current Law at the node is better shown to students. No problem; as you can see in section~\ref{curr-and-volt} you can use the position specifiers \verb|<>^_| after the key \IndexKey{i}:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[isource, l=$I_0$] (0,3)
     to[short, -*, i=$I_0$] (2,3)
@@ -546,11 +546,11 @@ One of the problems with this circuit is that we would like to have the current 
     to[R=$R_2$, i>_=$i_2$]
     (4,0) to[short, -*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, we would like to add voltages indication for carrying out the current formulas; as the default position of the voltage signs seems a bit cramped to me, I am adding the \IndexKey{voltage shift} parameter to make a bit more space for it\dots
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american, voltage shift=0.5]
     \draw (0,0)
     to[isource, l=$I_0$, v=$V_0$] (0,3)
@@ -560,11 +560,11 @@ Finally, we would like to add voltages indication for carrying out the current f
     to[R=$R_2$, i>_=$i_2$]
     (4,0) to[short, -*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \emph{Et voila!}. Remember that this is still \LaTeX, which means that you have done a description of your circuit, which is, in a lot of way, independent of the visualization of it. If you ever have to adapt the circuit to, say, a journal that forces European style and flows instead of currents, you just change a couple of things and you have what seems a completely different diagram:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european, voltage shift=0.5]
     \draw (0,0)
     to[isourceC, l=$I_0$, v=$V_0$] (0,3)
@@ -574,11 +574,11 @@ Finally, we would like to add voltages indication for carrying out the current f
     to[R=$R_2$, f>_=$i_2$]
     (4,0) to[short, -*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 And finally, this is still \TikZ, so that you can freely mix other graphics element to the circuit.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american, voltage shift=0.5]
     \draw (0,0)
     to[isource, l=$I_0$, v=$V_0$] (0,3)
@@ -590,7 +590,7 @@ And finally, this is still \TikZ, so that you can freely mix other graphics elem
     \draw[red, thick] (0.6,2.1) rectangle (4.2,3.8)
     node[pos=0.5, above]{KCL};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \clearpage
 
@@ -616,13 +616,13 @@ Obviously, the style and form of drawing a circuit is often a matter of personal
 
 We have to start the drawing from a generic point. Given that the idea is to have a reusable block, instead of positioning the op-amp and build around it, we will start from the input ``pole'':
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) node[above]{$v_i$} to[short, o-] ++(1,0)
     node[op amp, noinv input up, anchor=+](OA){\texttt{OA1}}
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In this snippet, notice that the only absolute coordinate is the first one; that will enable us to ``copy and paste'' the circuit in several places, or create a macro for it. We position a text node above it, and then draw a wire with a pole to a relative \texttt{(1,0)} coordinate: in other words, we \emph{move} 1~unit to the right drawing a short-circuit, which is the same as a wire. The usage of \texttt{to[short...]} simplifies the position of the pole, but notice that we could have also written:
 \begin{lstlisting}[numbers=none]
@@ -649,7 +649,7 @@ Now we can draw the resistors; let's start with $R_1$. We will draw it going dow
     \item draw the ground node.
 \end{itemize}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
     \draw (0,0) node[above]{$v_i$} to[short, o-] ++(1,0)
     node[op amp, noinv input up, anchor=+](OA){\texttt{OA1}}
@@ -657,7 +657,7 @@ Now we can draw the resistors; let's start with $R_1$. We will draw it going dow
     to[R=$R_1$] ++(0,-2) node[ground]{}
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 We are only missing the feedback resistor now. We will use \emph{orthogonal coordinates}, writing:
 \begin{lstlisting}[numbers=none]
@@ -676,7 +676,7 @@ You can use a separate \verb|\draw| command or just continue the path you were w
 
 Finally, we add the output and a couple of nodes:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
     \draw (0,0) node[above]{$v_i$} to[short, o-] ++(1,0)
     node[op amp, noinv input up, anchor=+](OA){\texttt{OA1}}
@@ -686,11 +686,11 @@ Finally, we add the output and a couple of nodes:
     to [short, *-o] ++(1,0) node[above]{$v_o$}
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The last step to obtain the final look is to add a bit of styling. We want the op-amp filled with a light cyan color, and we prefer to have the label aligned with the left side of the device:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \ctikzset{amplifiers/fill=cyan!20, component text=left}
 \begin{circuitikz}[scale=0.8, transform shape]
     \draw (0,0) node[above]{$v_i$} to[short, o-] ++(1,0)
@@ -701,7 +701,7 @@ The last step to obtain the final look is to add a bit of styling. We want the o
     to [short, *-o] ++(1,0) node[above]{$v_o$}
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \verb|\ctikzset| command choosing the style is better placed in the preamble, though. Style should be coherent for all the document body, so avoiding stating it for every circuit is normally the best strategy.
 
@@ -713,7 +713,7 @@ The easiest way to reuse the circuit is to put it in a macro. This is a very fle
 
 Defining a macro for our amplifier could be as easy as this:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \ctikzset{amplifiers/fill=cyan!20, component text=left}
 \newcommand\myNIA[4]{%1: name of this amplifier, %2 start coordinate, %3 R1, %4 R2
     \draw #2 coordinate(#1-in) to[short] ++(1,0)
@@ -724,13 +724,13 @@ Defining a macro for our amplifier could be as easy as this:
     to [short, *-] ++(1,0) coordinate(#1-out)
     ;
 }
-\end{LTXexample}
+\end{ctikzExample}
 
 We remove the open poles (it's better to draw them at the end to avoid artifacts) and then we make the names of the coordinates and of the nodes unique, by prepending a parameter that we will provide at every invocation. Then we remove the labels (for simplicity here) and add a couple of coordinates that we will be able to use from the outside when building our circuit.
 
 And we can use it like in the following:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.7, transform shape]
     \myNIA{OA1}{(0,0)}{$R_1$}{$R_2$}
     % start drawing from the output of OA1
@@ -741,7 +741,7 @@ And we can use it like in the following:
     \node [above] at (OA2-out) {$v_o$};
     \draw (OA1-out) -| (OA2-in);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \endgroup % remove the changes of the op-amp tutorial subsection
 \clearpage
@@ -759,17 +759,17 @@ The idea is to use relative coordinates and named nodes as much as possible, so 
 
 First of all, let's define a handy function to show the position of nodes:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \def\normalcoord(#1){coordinate(#1)}
 \def\showcoord(#1){coordinate(#1) node[circle, red, draw, inner sep=1pt,
     pin={[red, overlay, inner sep=0.5pt, font=\tiny, pin distance=0.1cm,
     pin edge={red, overlay}]45:#1}](){}}
 \let\coord=\showcoord
-\end{LTXexample}
+\end{ctikzExample}
 
 The idea is that you can use \verb|\coord()| instead of \verb|coordinate()| in paths, and that will draw small red \emph{markers} showing them. For example:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) node[npn](Q){};
     \path (Q.center) \coord(center)
@@ -778,7 +778,7 @@ The idea is that you can use \verb|\coord()| instead of \verb|coordinate()| in p
     \useasboundingbox
       (Q.south west) (Q.north east) +(.75,.3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 After the circuit is drawn, simply commenting out the second \verb|\let| command will hide all the markers.
 
@@ -786,26 +786,26 @@ So let's start with the first stage transistor; given that my preferred way of d
 
 \ctikzset{tripoles/mos style/arrows}
 \def\killdepth#1{{\raisebox{0pt}[\height][0pt]{#1}}}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
 \ctikzset{tripoles/mos style/arrows}
 \def\killdepth#1{{\raisebox{0pt}[\height][0pt]{#1}}}
 \path (0,0) -- (.5,0); % bounding box
 \draw (0,0) node[nmos](Q1){\killdepth{Q1}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 I had to do draw an invisible line to take into account the text for Q1 --- the text is not taken into account in calculating the bounding box. This is because the ``geographical'' anchors (\texttt{north}, \texttt{north west}, \dots) are defined for the symbol only. In a complex circuit, this is rarely a problem.
 
 Another thing I like to modify with respect to the standard is the position of the arrows in transistors, which are normally in the middle of the symbol. Using the following setting (see section~\ref{sec:styling-transistors}) will move the arrows to the start or end of the corresponding pin.
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \ctikzset{transistors/arrow pos=end}
-\end{LTXexample}
+\end{ctikzExample}
 
 The tricky thing about \verb|\killdepth{}| macro is the finicky details. Without the \verb|\killdepth| macro, the labels of different transistors will be adjusted so that the vertical center of the box is at the \texttt{center} anchor, and as an effect, labels with descenders (like Q) will have a different baseline than labels without. You can see this here (it's really subtle):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american,]
 \draw (0,0) node[nmos](Q1){q1} ++(2,0)
     node[nmos](M1){m1};
@@ -814,11 +814,11 @@ The tricky thing about \verb|\killdepth{}| macro is the finicky details. Without
    node[nmos](M1){\killdepth{m1}};
 \draw [red] (Q1.center) ++(0,-0.7ex) -- ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 We will start connecting the first transistor with the power supply with a couple of resistors. Notice that I am naming the nodes \texttt{GND}, \texttt{VCC} and \texttt{VEE}, so that I can use the coordinates to have all the supply rails at the same vertical position (more on this later).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american,]
     \draw (0,0) node[nmos,](Q1){\killdepth{Q1}};
     \draw (Q1.S) to[R, l2^=$R_S$ and \SI{5}{k\ohm}]
@@ -832,11 +832,11 @@ We will start connecting the first transistor with the power supply with a coupl
         (VCC) \coord(VCC)
         (VEE) \coord(VEE);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 After that, let's add the input part. I will use a named node here, referring to it to add the input source. Notice how the ground node is positioned: the coordinate \texttt{(in |- GND)} is the point with the horizontal coordinate of \texttt{(in)}  and the vertical one of \texttt{(GND)}, lining it up with the ground of the capacitor $C_1$ (you can think it as ``the point aligned vertically with \texttt{in} and horizontally with \texttt{GND}'').
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american, scale=0.7, transform shape]
 \draw (0,0) node[nmos,](Q1){\killdepth{Q1}};
 \draw (Q1.S) to[R, l2^=$R_S$ and \SI{5}{k\ohm}]
@@ -851,7 +851,7 @@ After that, let's add the input part. I will use a named node here, referring to
 \draw (in) to[C, l_=$C_2$,*-o]
     ++(-1.5,0) node[left](vi1){$v_i=v_{i1}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the only absolute coordinate here is the first one, \texttt{(0,0)}; so the elements are connected with relative movements and can be moved by just changing one number (for example, changing the \verb| to[C=$C_1$] ++(0,-1.5) | will move \emph{all} the grounds down).
 
@@ -1082,7 +1082,7 @@ I want a reusable block, so I will start from a coordinate and then use only rel
 
 Now we can add the ``and'' gates. For example, we can add the gates to the right like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) node[sr-ff](FF){} (FF.bup)
     node[above]{SR-FF};
@@ -1091,12 +1091,12 @@ Now we can add the ``and'' gates. For example, we can add the gates to the right
           (FF.pin 3) -- ++(-1,0) node[and port,
         anchor=out](AND2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can notice a pair of things here: first of all, the use of the \texttt{anchor=out} in the port, to tell \TikZ{} that we want the node moved so that the \texttt{out} anchor is the reference one. The second one is that we have repeated the absolute shift (the \texttt{++(-1, 0)}) twice. This is a bad practice; it is much better to have the ``free'' parameters of a schematic just stated once, so that we can change them in just one point.
 
 You can of course use a macro, like \verb|\newcommand{\andshift}{(-1,0)}| but it is much more elegant to do something like this:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) node[sr-ff](FF){} (FF.bup)
     node[above]{SR-FF};
@@ -1105,13 +1105,13 @@ You can of course use a macro, like \verb|\newcommand{\andshift}{(-1,0)}| but it
         (FF.pin 3) -- (FF.pin 3 -| AND1.out)
         node[and port, anchor=out](AND2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In this snippet, the coordinate \texttt{(FF.pin 3 -| AND1.out)} is the \TikZ{} way to say ``the point which is horizontally straight from \texttt{FF.pin 3} and vertically form \texttt{AND1.out}''. That way one can change the number \texttt{-1} to move both AND ports nearer or farther away.
 
 Now we can add the not port. Since version~\texttt{1.1.3} you can use a path-style not port, so you can just say: this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
 \draw (0,0) node[sr-ff](FF){} (FF.bup)
     node[above]{SR-FF} (FF.pin 1) -- ++(-1,0)
@@ -1121,7 +1121,7 @@ Now we can add the not port. Since version~\texttt{1.1.3} you can use a path-sty
     (AND1.in 1) to[short, -*] ++(-1,0) coordinate(in)
     to[inline not] (in |- AND2.in 2) -- (AND2.in 2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In earlier versions, you should have found the center point between the two terminal, position the ``not'' shape and ten connect it, like for example (this code must stay into the \verb|\draw| command):
 
@@ -1264,21 +1264,21 @@ Normally, path-style components do not need anchors, although they have them jus
 \end{center}
 In the case of bipoles, also shortened geographical anchors exists. In the description, it will be shown when a bipole has additional anchors. To use the anchors, just give a name to the bipole element using the syntax \texttt{name=\emph{myname}}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[potentiometer, name=P, mirror] ++(0,2);
     \draw (P.wiper) to[L] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Alternatively, that you can use the shape form, and then use the \texttt{left} and \texttt{right} anchors to do your connections.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[potentiometershape, rotate=-90](P){};
     \draw (P.wiper) to[L] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Border anchors}\label{sec:bipoles-border-anchors}
 
@@ -1349,7 +1349,7 @@ You can see from the example below (notice the blue curve using a spline line). 
 
 In the last (green) example, you can see a workaround using local path and the key \IndexKey{current point is local} that will work for older (and do not create problems in newer) versions.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 Plotted using \TikZ\ version \pgfversion{} and Circui\TikZ\ version \pgfcircversion{}.
 
 \begin{tikzpicture}
@@ -1368,7 +1368,7 @@ Plotted using \TikZ\ version \pgfversion{} and Circui\TikZ\ version \pgfcircvers
     \draw[color=green!50!black] (0,0)
         {[current point is local] to[R] +(2,0)} +(0,0) -- ++(0,-1);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Customization}
@@ -1385,7 +1385,7 @@ Note that the details of the parameters that are not described in the manual can
 Perhaps the most important parameter is \IndexKey{bipoles/length}  (default \SI{1.4}{cm}, you can use the currently set value with \verb!\ctikzvalof{bipoles/length}!), which
 can be interpreted as the length of a resistor (including reasonable connections): all other lengths are relative to this value. For instance:
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \ctikzset{bipoles/length=1.4cm}
 \begin{circuitikz}[scale=1.2]\draw
   (0,0) node[anchor=east] {B}
@@ -1397,9 +1397,9 @@ can be interpreted as the length of a resistor (including reasonable connections
   (3,0) -- (1,0)
   (1,2) to[short, -o] (0,2) node[anchor=east]{A}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \ctikzset{bipoles/length=.8cm}
 \begin{circuitikz}[scale=1.2]\draw
   (0,0) node[anchor=east] {B}
@@ -1411,11 +1411,11 @@ can be interpreted as the length of a resistor (including reasonable connections
   (3,0) -- (1,0)
   (1,2) to[short, -o] (0,2) node[anchor=east]{A}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The changes on \IndexKey{bipoles/length} should, however, be globally applied to every path, because they affect every element --- including the poles. So you can have artifacts like the one in the second line below:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     bigR/.style={R, bipoles/length=3cm}
     ]
@@ -1424,11 +1424,11 @@ The changes on \IndexKey{bipoles/length} should, however, be globally applied to
       to[R, o-o] ++(2,0); % will fail here
     \draw (0,0) to [R, o-o] ++(4,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Several groups of components, on the other hand, have a special \IndexKey{scale} parameter that can be used safely in this case (starting with 0.9.4 --- more groups of components will be added going forward); the key to use will be explained in the specific description of the components. For example, in the case of resistors you have \IndexKey{resistors/scale} available:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     bigR/.style={R, resistors/scale=1.8}
     ]
@@ -1437,14 +1437,14 @@ Several groups of components, on the other hand, have a special \IndexKey{scale}
       to[R, o-o] ++(2,0); % ok now
     \draw (0,0) to [R, o-o] ++(4,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Never use \texttt{scale}, \texttt{xscale} or~\texttt{yscale} in a path-style component (i.e., inside a \texttt{to[...]}) command.
 
 \paragraph{Mirroring and flipping path-style components}\label{sec:mirror-flip-path}
 
 To change the orientation of path-style components, \emph{never} use \texttt{xscale=-1} nor~\texttt{yscale=-1}. That will mess up the path completely. Use the \IndexKey{mirror} and \IndexKey{invert}  options:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[N/.style={
     font=\tiny\ttfamily, above}]
     \draw (0,0) to [put] ++(0,2)
@@ -1456,19 +1456,19 @@ To change the orientation of path-style components, \emph{never} use \texttt{xsc
     \draw (3,0) to [put, mirror, invert] ++(0,2)
         node[N]{both};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Thickness of the lines}\label{sec:legacy-thickness} (globally)
 
 The best way to alter the thickness of components is using styling, see section~\ref{sec:styling-thickness}. Alternatively, you can use ``legacy'' classes like \texttt{bipole}, \texttt{tripoles} and so on ---
 for example changing the parameter \IndexKey{bipoles/thickness} (default 2). The number is relative to the thickness of the normal lines leading to the component.
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
     \ctikzset{bipoles/thickness=1}
     \tikz \draw (0,0) to[C=1<\farad>] (2,0); \par
     \ctikzset{bipoles/thickness=4}
     \tikz \draw (0,0) to[C=1<\farad>] (2,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Shape of the components} (on a per-component-class basis)
 \label{par:shape-of-the}
@@ -1478,15 +1478,15 @@ Notice however that the ``internal'' parameters, the ones not commented in this 
 
 It is recommended to use the styling parameters to change the shapes; they are not so fine-grained (for example, you can change the width of resistor), but they are more stable and coherent across your circuit.
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
     \tikz \draw (0,0) to[R=1<\ohm>] (3,0); \par
     \ctikzset{resistors/width=2}
     \tikz \draw (0,0) to[R=1<\ohm>] (3,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 To change the height, you can use (locally) the class scale parameter and the width; you can even define a style that will work across the resistor styles:
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
     \ctikzset{american}
     \tikz \draw (0,0) to[R=1<\ohm>] (4,0);
 
@@ -1496,7 +1496,7 @@ To change the height, you can use (locally) the class scale parameter and the wi
 
     \ctikzset{european}
     \tikz \draw (0,0) to[R=1<\ohm>, tallR] (4,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Descriptions}
 \label{sec:usage-descriptions}
@@ -1548,7 +1548,7 @@ Explanation of the parameters:\\
 
 Mirroring and flipping of node components is obtained by using the \TikZ\ keys \IndexKey{xscale} and \IndexKey{yscale}. Notice that these parameters also affect text labels, so they need to be un-scaled by hand. Notice that you \textbf{do not} use \texttt{xscale} or~\texttt{yscale} in a path-style component, see section~\ref{sec:mirror-flip-path} for that case.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.7, transform shape]
     \draw (0,3) node[op amp]{OA1};
     \draw (3,3) node[op amp, xscale=-1]{OA2};
@@ -1556,7 +1556,7 @@ Mirroring and flipping of node components is obtained by using the \TikZ\ keys \
     \draw (3,0) node[op amp, xscale=-1]{%
         \scalebox{-1}[1]{OA4}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 To simplify this task, \Circuitikz{} has three helper macros ---\IndexKey[ctikzflip]{}\verb|\ctikzflipx{}|,
 \verb|\ctikzflipy{}|, and \verb|\ctikzflipxy{}|, that can be used to ``un-rotate''
@@ -1564,14 +1564,14 @@ the text of nodes drawn with, respectively,
 \texttt{xscale=-1}, \texttt{yscale=-1}, and \texttt{scale=-1} (which is equivalent to
 \texttt{xscale=-1, yscale=-1}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.7, transform shape]
     \draw (0,3) node[op amp]{OA1};
     \draw (3,3) node[op amp, xscale=-1]{\ctikzflipx{OA2}};
     \draw (0,0) node[op amp, yscale=-1]{\ctikzflipy{OA3}};
     \draw (3,0) node[op amp,  scale=-1]{\ctikzflipxy{OA4}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Anchors}
@@ -1756,7 +1756,7 @@ If you just want to use one style, you can load and activate it in one command w
 
 The \texttt{example} style file will simply make the amplifiers filled with light blue:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[op amp]{OA1};
 \end{circuitikz}
@@ -1764,7 +1764,7 @@ The \texttt{example} style file will simply make the amplifiers filled with ligh
 \begin{circuitikz}[example circuit style]
     \draw (0,0) node[op amp]{OA1};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 \ctikzloadstyle{legacy}
 \ctikzloadstyle{romano}
 
@@ -1835,7 +1835,7 @@ To define a block you use the \verb|\ctikzsubcircuitdef| macro; this macro has 3
 
 Let's see that with an example:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \ctikzsubcircuitdef{optovishay}{in 1, out 1, in 2, out 2, center}{%
     % reference anchor is -center
     coordinate(#1-center)
@@ -1855,7 +1855,7 @@ Let's see that with an example:
     % leave the position of the path at the center
     (#1-center)
 }
-\end{LTXexample}
+\end{ctikzExample}
 
 Our element is a symbol for an optocoupler; in this case is the symbol used for one cell of the double \href{https://www.vishay.com/docs/84639/vo1263aa.pdf}{Vishay vo1263 device}.
 
@@ -1884,7 +1884,7 @@ We also define a coordinate \texttt{-up} (you can define more coordinates, in ad
 To use the subcircuit, an additional step is needed. Somewhere you have to \emph{activate} it. This is needed to calculate the relative positions of anchors using the current set of style parameters. The normal place is to activate it just before usage; to do that you use the command \verb|\ctikzsubcircuitactivate| with the name of the subcircuit. That will define a new command, \texttt{\textbackslash\emph{nameofthesubcircuit}} that you can use then in your paths.
 
 So to check your subcircuit while defining it you can use this simple snippet:
-\begin{LTXexample}
+\begin{ctikzExample}
 \ctikzsubcircuitactivate{optovishay}
 \begin{tikzpicture}
     \draw (0,0) \optovishay{one}{};
@@ -1893,14 +1893,14 @@ So to check your subcircuit while defining it you can use this simple snippet:
         \optovishay{two}{in 1};
     \node [above] at (two-up) {O2};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Scaling, flipping and rotating subcircuits}
 \label{par:scaling-flipping-and}
 
 To scale and rotate a subcircuit you have to include it into a \texttt{scope} with the appropriate \texttt{scale} and rotation commands. Notice that, as in general in \Circuitikz, global scales that affect rotation works only if \IndexKey{transform shape} is issued (see~\ref{sec:bugs}); nesting \texttt{transform shape} normally works, but it has been really lightly tested.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \ctikzsubcircuitactivate{optovishay}
 \begin{tikzpicture}[scale=0.8, transform shape]
     \draw (0,0) \optovishay{three}{};
@@ -1910,7 +1910,7 @@ To scale and rotate a subcircuit you have to include it into a \texttt{scope} wi
     \end{scope}
     \draw[blue] (three-out 2) -| (four-out 2);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Parameters in subcircuits}
 \label{sec:parameters-in-subcircuits}
@@ -1921,31 +1921,31 @@ One possibility is to use additional macros and anchors for positioning, like in
 
 Suppose you have defined
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
     \ctikzsubcircuitdef{divider}{in, out}{%
         coordinate (#1-in) to[R, l=~, name=#1-rh, -*] ++(2,0)
         coordinate(#1-tmp) to[R, l=~, name=#1-rl] ++(0,-2)
         node[tlground]{} (#1-tmp) --++(0.5,0) coordinate(#1-out)
     }
-\end{LTXexample}
+\end{ctikzExample}
 
 then you can additionally define:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
     \newcommand{\mydiv}[4]{
         \divider{#1}{#2} (#1-rh.n) node[above]{#3}
         (#1-rl.n) node[right]{#4} (#1-out)
     }
-\end{LTXexample}
+\end{ctikzExample}
 
 And finally do:
-\begin{LTXexample}
+\begin{ctikzExample}
 \ctikzsubcircuitactivate{divider}
 \begin{tikzpicture}
     \draw (0,0) \mydiv{a}{in}{$R_1$}{$R_2$};
     \draw (a-out) -- \mydiv{b}{in}{$R_3$}{$R_4$};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Using \texttt{pic}s (with parameters)}
 \label{sec:using-pic-s}
@@ -1961,7 +1961,7 @@ code={
 
 Since \texttt{v1.8.0}\footnote{See \href{https://github.com/circuitikz/circuitikz/issues/866}{this issue} for more details; be warned that they will \textbf{not} work at all in earlier versions.} you can also use the standard \TikZ{} \IndexKey{pic}s as subcircuits, with the advantage to be able to define (up to 9) parameters.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{pics/divider/.style n args={2}{
 code={
     \draw (0,0) coordinate(-in) to[R=#1, -*] ++(2,0)
@@ -1974,7 +1974,7 @@ code={
         (one-out) pic(two){divider={$R_3$}{$R_4$}};
     \node [above] at (one-corner) {$v_{12}$};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 The main limitation of \texttt{pic}s is that natively they do not have options to place them with internal anchors, like the \texttt{anchor=\dots} options of nodes. Fortunately, Andrew Stacey's fine \href{https://ctan.org/pkg/tikzmark?lang=en}{\texttt{tikzmark} library} provides that function. You have to just add \verb!\usetikzlibrary{tikzmark}! in your preamble, and then add the option to the pic invocation:
 
@@ -1984,13 +1984,13 @@ The main limitation of \texttt{pic}s is that natively they do not have options t
 
 For example, suppose you want to attach your divider to a BJT base:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     %% \usetikzlibrary{tikzmark}
     \draw (0,0) node[npn](Q){}
         (Q.B) pic[pic anchor=(-out)]{divider={$R_1$}{$R_2$}};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that \IndexKey{pic anchor} needs an additional compilation pass to position the subcircuit correctly.
 This double pass is usually not a problem, but be prepared to have the pic positioned incorrectly after the first run.
@@ -2008,14 +2008,14 @@ With a recent enough \IndexKey{tikzmark}\footnote{The version must be \textbf{gr
 
 Finally, if you want to rotate the pic (warning: lightly tested!) remember that you need \texttt{transform shape} to have a correct behavior.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \draw (0,0)
         pic(one){divider={$R_1$}{$R_2$}} (one-out)
         pic[rotate=45, transform shape](two)
             {divider={$R_A$}{$R_B$}};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 \endgroup % to isolate the definition of pics/divider
 
 \subsubsection{Using macros}
@@ -2030,7 +2030,7 @@ In this case, probably an old-fashioned macro, using partway coordinate specifie
 \footnote{See \href{https://tikz.dev/tikz-coordinates\#sec-13.5.3}{\TikZ{} manual section 13.5}}
 could be the best option for this task. Below, one possible example (not optimized at all!).
 
-\begin{LTXexample}[only code, store=ChopperByTerminals]
+\begin{ctikzExample}[only code, store=ChopperByTerminals]
 \NewDocumentCommand{\ChopperByTerminals}{O{} O{0.2cm} m m m}{%
     % #1 -> options to the draw command
     % #2 -> half width
@@ -2058,11 +2058,11 @@ could be the best option for this task. Below, one possible example (not optimiz
     \draw [draw, thick, line join=round, #1] (#5-P1A) -- (#5-P2B) --
         (#5-P1B) -- (#5-P2A) -- (#5-P1A);
 }
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use this definition as follows, for example:
 
-\begin{LTXexample}[pos=b, restore=ChopperByTerminals]
+\begin{ctikzExample}[pos=b, restore=ChopperByTerminals]
 \begin{tikzpicture}[]
     \node[op amp](A) at (0,0) {};
     \ChopperByTerminals[draw=red][-0.2cm]{A.-}{A.+}{chopper in}
@@ -2080,7 +2080,7 @@ You can use this definition as follows, for example:
         \node[circle, draw, inner sep=1pt, pin={[font=\tiny, fill=white]60:C-\a}]
             at (C-\a) {};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \section{The components: list}
@@ -2155,7 +2155,7 @@ You can change the scale of the power supplies by setting the key \IndexKey{powe
 Given that the power supply symbols are basically arrows, you can change them using all the options of the \texttt{arrows.meta} package (see the \TikZ\ manual for details) by changing the keys \IndexKey{monopoles/vcc/arrow} and \IndexKey{monopoles/vee/arrow} (the default for both is \texttt{legacy}, which will use the old code for drawing them).
 Note that the anchors are at the start of the connecting lines, and that geographical anchors are just approximation if you change the arrow symbol!
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     % next macro is available in ctikzmanutils.sty
     \def\coord(#1){\showcoord(#1)<0:0.3>}
@@ -2168,13 +2168,13 @@ Note that the anchors are at the start of the connecting lines, and that geograp
     node[vcc](vcc){VCC} \coord(vcc) ++(2,0)
     node[vee](vee){VEE} \coord(vee);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 However, arrows in \TikZ{} are in the same class with the line thickness, so they do not scale with neither the class \texttt{power supplies} scale nor the global scale parameter (you should use \texttt{transform canvas=\{scale\dots\}} for this).
 
 If you want the arrows to behave like the legacy symbols (which are shapes), \emph{only in the arrow definitions}, you can use the special length parameter \verb|\scaledwidth|\footnote{Thanks to @Schrödinger's cat on \href{https://tex.stackexchange.com/a/506249/38080}{\TeX{} stackexchange site}} in the arrow definition, which correspond to the width of the legacy \texttt{vcc} or \texttt{vee}. Compare the effects on the following circuit.
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \ctikzset{%
     monopoles/vcc/arrow={Triangle[width=0.8*\scaledwidth, length=\scaledwidth]},
     monopoles/vee/arrow={Triangle[width=6pt, length=8pt]},
@@ -2195,7 +2195,7 @@ If you want the arrows to behave like the legacy symbols (which are shapes), \em
     \draw (A1.+) -- ++(-0.5,0) to[battery2, invert, l_=\SI{2}{V}] ++(0,-1) node[ground]{};
     \draw (A1.out) to[short, -o] ++(0.5,0) node[above](vo){$v_o$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Resistive bipoles}
@@ -2254,7 +2254,7 @@ Other miscellaneous resistor-like devices:
 Since version \texttt{0.9.5}, you can control the position of the wiper in potentiometers using the key \IndexKey{wiper pos}, which is a number in the range $[0,1]$. The default middle position is \texttt{wiper pos=0.5}.
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \ctikzset{resistors/width=1.5, resistors/zigs=9}
     \draw (0,0) to[pR, name=A] ++(0,-4);
@@ -2264,11 +2264,11 @@ Since version \texttt{0.9.5}, you can control the position of the wiper in poten
     \foreach \i in {A, B, C}
         \node[right] at (\i.wiper) {\i};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since version \texttt{1.6.0}, potentiometers and variable resistors have extra anchors\footnote{Thanks to a suggestion by \href{https://github.com/circuitikz/circuitikz/issues/663}{Dr. Matthias Jung on GitHub}}, to allow this kind of circuit (that seems to be common in some region):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \draw (0,0) to[battery2, l=E] ++(0,4.5)
         -- ++(2,0) coordinate(tmp)
@@ -2280,13 +2280,13 @@ Since version \texttt{1.6.0}, potentiometers and variable resistors have extra a
         |- (P.wiper);
     \draw (p) to[rmeterwa, t=V] (tmp-|p) -- (tmp);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Generic sensors anchors}\label{sec:sensors-anchors}
 Generic sensors have an extra anchor named \IndexKey{label}  to help position the type of dependence, if needed:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,2) to[sR, l=$R$, name=mySR] ++(3,0);
    \node [font=\tiny, right] at(mySR.label) {-t\si{\degree}};
@@ -2295,7 +2295,7 @@ Generic sensors have an extra anchor named \IndexKey{label}  to help position th
    \draw (0,-2) to[sC, l=$C$, name=mySC] ++(3,0);
    \node [font=\tiny, below right, inner sep=0pt] at(mySC.label) {+H\si{\%}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The anchor is positioned just on the corner of the segmented line crossing the component.
 
@@ -2310,7 +2310,7 @@ You can change the width of these components (all the resistive bipoles together
 For the american style resistors, you can change the number of ``zig-zags'' by setting the key
 \IndexKey{resistors/zigs} (default value \texttt{3}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
         longpot/.style = {pR, resistors/scale=0.75,
         resistors/width=1.6, resistors/zigs=6}]
@@ -2319,13 +2319,13 @@ For the american style resistors, you can change the number of ``zig-zags'' by s
    \ctikzset{resistors/scale=1.5}
    \draw (0,-1.5) to[R, l=$R$] ++(4,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Thickness.}\label{sec:resistor-thickness} The line thickness of the resistive components is governed by the class thickness; you can change it assigning a value to the key \IndexKey{resistors/thickness} (default \texttt{none}, that means \texttt{bipoles/thickness} is used, and that defaults to \texttt{2.0}; the value is relative to the base line thickness).
 
 We can call \emph{modifiers} the elements that are added to the basic shape to express some characteristics of the component; for example the arrows for the variable resistors or the bar for the sensors. Normally the thickness of these elements are the same as the one chosen for the component\footnote{Due to a bug in versions before 1.3.4, that didn't happen for thermistors}. You can change their thickness with the class key \IndexKey{modifier thickness} which is relative to the main component thickness.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,2) to[vR] ++(2,0) to[sR] ++(2,0);
     \ctikzset{resistors/thickness=4}
@@ -2333,7 +2333,7 @@ We can call \emph{modifiers} the elements that are added to the basic shape to e
     \ctikzset{resistors/modifier thickness=0.5}
     \draw (0,0) to[vR] ++(2,0) to[sR] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Arrows.\label{sec:tunablearrows}} You can change the arrow tips used in tunable resistors (\texttt{vR}, \texttt{tgeneric}) with the key \IndexKey{tunable end arrow}  and in potentiometers with the key \IndexKey{wiper end arrow} (by default the key is the word ``\texttt{default}'' to obtain the default arrow, which is \texttt{latexslim} for both).
 \label{par:arrows-sec-tunablearrows}
@@ -2342,7 +2342,7 @@ Also you can change the start arrow with the corresponding \IndexKey{tunable sta
 You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
 For the \texttt{photoresistor} and the two ``flavors'' of the light-dependent resistor (\texttt{ldR}, american or european), the style of the arrows follow the \IndexKey[opto arrows]{opto} commands as in the photodiodes and phototransistor: see~\ref{sec:opto-arrows}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[american]
     % globally all the potentiometrs
     \ctikzset{wiper end arrow={Kite[open]},
@@ -2353,7 +2353,7 @@ For the \texttt{photoresistor} and the two ``flavors'' of the light-dependent re
        tunable start arrow={Bar}, invert] ++(0,-2)
        to[pR, mirror] ++(-4,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \begingroup % protect changes to resistors
 \newcommand\showjoin[1]{%
@@ -2455,7 +2455,7 @@ Finally, here is the detailed shape with thickness 2 (red=0, blue=0.05, green=0.
 Capacitors are fillable since \texttt{v1.4.1}; this is normally just a stylistic option but in the case of
 ferroelectric capacitors that could be used to show the state of the hysteresis of the component.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \ctikzset{capacitors/.cd,
     thickness=4, modifier thickness=0.5}
@@ -2464,7 +2464,7 @@ ferroelectric capacitors that could be used to show the state of the hysteresis 
     \node [font=\tiny, above right, inner sep=1pt]
         at(C2.kink left) {$S_1$};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 There is also the (deprecated\footnote{Thanks to \href{https://tex.stackexchange.com/questions/509594/polar-capacitor-orientation-in-circuitikz-seems-wrong}{Anshul Singhv for noticing}.} --- its polarity is not coherent with the rest of the components) \IndexKey{polar capacitor}; please do not use it.
 
@@ -2481,20 +2481,20 @@ Variable capacitors arrow tips follow the settings  of resistors, see section~\r
 
 The relative size of the capacitors is a bit of a mixed bag, because each one has historically different internal parameters that makes maintaining coherence quite difficult. In \texttt{v1.4.1} this has changed and now you can use styling options to change the way the capacitors look. The main parameter you can set is \IndexKey{capacitors/width} (default \texttt{0.2}), which controls the standard distance between plates. That will change all the components (notice that \texttt{piezoelectric} and \texttt{cpe} default width is twice the size of a standard capacitor --- although this is not evident for the \texttt{cpe} given its shape.)
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \draw (0,1) to[C=aaa] ++(2,0) to[cpe=bbb] ++(2,0);
     \draw[color=red] (0,0) to [C] ++(2,0);
     \draw[color=blue] (0,0) to [cpe] ++(2,0)
     to[cpe, fill=yellow, capacitors/width=0.1] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \IndexKey{capacitors/height} key is available also to set the height of the capacitor; the default is \texttt{0.6} for most of the capacitors, but \texttt{0.5} for electrolytic ones and \texttt{0.7} for piezoelectric. When used, it will set all of them at the same value, which is a good thing.
 
 If you want that only a specific kind of capacitor has a different value for a key, you can always use a style which will have a local scope, as in the following example.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{tikzpicture}
         \draw (0,1) to [C] ++(1,0) to [elko] ++(1,0);
         \ctikzset{capacitors/width=0.15, capacitors/height=0.5}
@@ -2502,7 +2502,7 @@ If you want that only a specific kind of capacitor has a different value for a k
         \tikzset{big elko/.style={elko=#1, capacitors/width=0.3}}
         \draw (0,-1) to [C] ++(1,0) to[big elko] ++(1,0);
     \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Inductors}
@@ -2550,7 +2550,7 @@ You can change the width of these components (all the inductors together, unless
 Moreover, you can change the number of ``coils'' drawn by setting the key
 \IndexKey{inductors/coils} (default value \texttt{5} for cute inductors and \texttt{4} for american ones). \textbf{Notice} that the minimum number of \texttt{coils} is \texttt{1} for american inductors, and \texttt{2} for cute ones.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
         longL/.style = {cute inductor, inductors/scale=0.75,
         inductors/width=1.6, inductors/coils=9}]
@@ -2559,12 +2559,12 @@ Moreover, you can change the number of ``coils'' drawn by setting the key
    \ctikzset{inductors/scale=1.5, inductor=american}
    \draw (0,-1.5) to[L, l=$L$] ++(4,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Chokes} can have single and double lines, and can have the line thickness adjusted (the value is relative to the thickness of the inductor). In general, you should use the anchors (see~\ref{sec:inductors-core-anchors}) to add core lines to inductors.
 \label{par:chokes}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[cute choke] ++(3,0);
     \draw (0,-1) to[cute choke, twolineschoke] ++(3,0);
@@ -2574,7 +2574,7 @@ Moreover, you can change the number of ``coils'' drawn by setting the key
     \draw (0,-2) to[cute choke] ++(3,0);
     \draw (0,-3) to[cute choke, onelinechoke] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Inductors anchors}
@@ -2586,7 +2586,7 @@ For inductive sensors, you have the same anchors than in the case of resistive s
 \label{par:taps}
 Inductors have an additional anchor, called \IndexKey{midtap}, that connects to the center of the coil ``wire''. Notice that this anchor could be on one side or the other of the component, depending on the number of loops of the element; if you need a fixed position, you can use the geographical anchors.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     loops/.style={circuitikz/inductors/coils=#1}]
 \ctikzset{cute inductors}
@@ -2598,12 +2598,12 @@ to[L, loops=6, name=D] ++(2,0);
 \foreach \i in {A, B, C, D}
   \node[circle, fill=red, inner sep=1pt] at (\i.midtap){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Core anchors.}\label{sec:inductors-core-anchors}
 Inductors have additional anchors to add core lines (for historical reasons, there is a \IndexKey{cute choke} component also, but to use inductors in the chosen style you'd better use these anchors). The anchors are called \IndexKey{core west} and \IndexKey{core east} and they are positioned at a distance that you can tweak with the \texttt{\textbackslash ctikzset} key \IndexKey{bipoles/inductors/core distance} (default \texttt{2pt}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}[]
         \ctikzset{american}
         \draw (0,3) to[L=$L$, name=myL] ++(2,0);
@@ -2615,7 +2615,7 @@ Inductors have additional anchors to add core lines (for historical reasons, the
         \draw (0,0) to[L=$L$, name=myL, label distance=2pt] ++(2,0);
         \draw[thick, double] (myL.core west) -- (myL.core east);
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the core lines will \textbf{not} change the position of labels. You have to move them by hand if needed (or position them on the other side); see~\ref{sec:adjust-label-position}.
 
@@ -2631,7 +2631,7 @@ to help positioning dots when specifying mutual inductance signs. The anchors ar
 and as you can see, you have to be careful if you use dot anchors and core anchors together.
 You can change the position of the dots by changing the keys \IndexKey{bipoles/inductors/dot x distance} (default \texttt{4pt}), which represent how much the dot extends outside the component width, and the corresponding \IndexKey[bipoles/inductors/dot y distance]{dot y distance} (default \texttt{1pt}), which serves the same scope in the height direction.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \ctikzset{bipoles/inductors/.cd, dot x distance=3pt,
         dot y distance=0pt}
@@ -2643,7 +2643,7 @@ You can change the position of the dots by changing the keys \IndexKey{bipoles/i
         to[out=-45, in=45] node[right]{$M$}
         ([yshift=0.2cm]l2.north);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the position of the dot anchors does not coincide with the position of the dots in the transformers (see section~\ref{sec:transformers}), because there they depend on the size of the complete double-bipole more that on the size of the inductances.
 
@@ -2761,17 +2761,17 @@ For basically stylistic reasons, there is a different, more compact, shape avail
 
 When inserting a thyristor, a triac or a potentiometer, one needs to refer to the third node-gate (\IndexKey{gate} or \texttt{G}) for the former two; wiper (\IndexKey{wiper} or \texttt{W}) for the latter one. This is done by giving a name to the bipole:
 \label{bipole-naming}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[Tr, n=TRI] (2,0)
         to[pR, n=POT] (4,0);
   \draw[dashed] (TRI.G) -| (POT.wiper)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As commented above, you can change the shape of these devices (globally or locally) setting the key \texttt{thyristor style=compact} (the default is \texttt{legacy}). Additionally, normally the plain \texttt{GTO} symbols come without the arrows, but you can add them using a syntax similar to the one explained in section~\ref{sec:tunablearrows} using the arrow group \IndexKey[gto gate arrows]{gto gate}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}[]
         \ctikzset{thyristor style=compact}
         \draw (0,0) to[GTO=$G_1$] ++(0,-3);
@@ -2779,7 +2779,7 @@ As commented above, you can change the shape of these devices (globally or local
         \draw (2,0) to[GTO*=$G_2$, mirror] ++(0,-3);
         \draw (4,0) to[GTOb-=$G_2$, mirror] ++(0,-3);
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that you can set both \texttt{gto gate end arrow} and \texttt{gto gate start arrow} --- choosing just one of the two you can decide the ``rotation'' direction of the symbol. There is little space though, so don't overdo it.
 
@@ -2787,7 +2787,7 @@ Notice that you can set both \texttt{gto gate end arrow} and \texttt{gto gate st
 
 You can change the scale of the diodes by setting the key \IndexKey{diodes/scale}  to something different from the default \texttt{1.0}. In Romano's opinion, diodes are somewhat big with the default style of the package, so a setting like \verb|\ctikzset{diodes/scale=0.6}| is recommended.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,1) to[D, l=$D$] ++(2,0)
       node[npn, anchor=B]{};
@@ -2795,11 +2795,11 @@ You can change the scale of the diodes by setting the key \IndexKey{diodes/scale
    \draw (0,-1) to[D, l=$D$] ++(2,0)
       node[npn, anchor=B]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Optical devices arrows}\label{sec:opto-arrows} You can change the direction of the LEDs and photodiodes' arrows by using the binary keys \IndexKey{led arrows from cathode} and \IndexKey{pd arrows to cathode} (the default are \IndexKey{led arrows from anode} and \IndexKey{pd arrows to anode}), as you can see in the following example.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \ctikzset{led arrows from anode} % default
         \ctikzset{pd arrows to anode}    % default
@@ -2819,7 +2819,7 @@ You can change the scale of the diodes by setting the key \IndexKey{diodes/scale
         \ctikzset{empty diodes}
         \draw (0,-6) to[leD] ++(1.5,0) to[pD] ++(1.5,0);
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since version \texttt{1.5.5}\footnote{Thanks to the idea by \href{https://github.com/circuitikz/circuitikz/issues/655}{Dr. Matthias Jung on GitHub}.}, you can change the arrows used for LEDs, photodiodes and laser diodes with the generic arrows options shown in~\ref{sec:tunablearrows}, using the name \IndexKey[opto arrows]{opto}, like in the following (overdone) example. Normally you want just to change the \texttt{end arrow}\dots
 
@@ -2838,7 +2838,7 @@ As you can see, you can also have the option to globally change the color, relat
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
 \newcommand{\optos}{%
     to[leD] ++(1.5,0) to[pD*] ++(1.5,0)
@@ -2863,12 +2863,12 @@ As you can see, you can also have the option to globally change the color, relat
     \draw (0,0) \optos;
 \end{scope}
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Zener and TVS diode options} You can change the shape of the Zener \texttt{ZZener} and \texttt{TVS} diodes using the flag \IndexKey{diode straight whiskers} (and reset it with the option \IndexKey{diode sloped whiskers}); this will change the ``whiskers'' of the diodes to be at a right angle\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/836}{Dr. Matthias Jung}} instead the sloped normal way.
 \label{par:zener-and-tvs}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \draw (0,1) to [zzDo] ++(1,0) to[zzD-] ++(1,0)
         to[zzD*] ++(1,0) to[tvsD-] ++(2,0);
@@ -2876,7 +2876,7 @@ As you can see, you can also have the option to globally change the color, relat
     \draw (0,0) to [zzDo] ++(1,0) to[zzD-] ++(1,0)
         to[zzD*] ++(1,0) to[tvsD-] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Sources and generators}
 \label{sec:sources-and-generators}
@@ -2920,14 +2920,14 @@ Similarly, if (default behavior) \IndexKey{europeanvoltages} option is active (o
       \footnotetext{The configurable open shape of the \texttt{sinusoidal current source} has been added by \href{https://github.com/circuitikz/circuitikz/pull/737}{Maximilian Martin}}
 \end{groupdesc}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \draw (0,2) to[sV=$V$] ++(3,0);
    \draw (0,1) to[sI=$I$] ++(3,0);
    \ctikzset{bipoles/isourcesin/angle=80}
    \draw (0,0) to[sI] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Controlled sources}
 \label{sec:controlled-sources}
@@ -2967,7 +2967,7 @@ In this case, the ``direction''  of the source is undefined. Noise sources are f
 \end{groupdesc}
 
 You can change the fill color with the key \IndexKey[noise sources/fillcolor]{circuitikz/bipoles/noise sources/fillcolor}:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw(0,0) to [nV, l=$e_n$] ++(2,0);
     \draw(0,-2) to [nI, l=$i_n$] ++(2,0);
@@ -2976,10 +2976,10 @@ You can change the fill color with the key \IndexKey[noise sources/fillcolor]{ci
         \draw(3,-2) to [nI, l=$i_n$] ++(2,0);
     \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you prefer a patterned noise generator (similar to the one you draw by hand) you can use the fake color \texttt{dashed}:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw(0,0) to [nV, l=$e_n$] ++(2,0);
     \draw(0,-2) to [nI, l=$i_n$] ++(2,0);
@@ -2988,10 +2988,10 @@ If you prefer a patterned noise generator (similar to the one you draw by hand) 
         \draw(3,-2) to [nI, l=$i_n$] ++(2,0);
     \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that if you choose the dashed style, the noise sources are fillable:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{bipoles/noise sources/fillcolor=dashed}
     \draw(0,0) to [nV, l=$e_n$] ++(2,0);
@@ -3001,7 +3001,7 @@ Notice that if you choose the dashed style, the noise sources are fillable:
         \draw(3,-2) to [nI, l=$i_n$, fill=blue!50!white] ++(2,0);
     \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Special sources}
 \label{sec:special-sources}
@@ -3027,18 +3027,18 @@ Notice that if you choose the dashed style, the noise sources are fillable:
 
 The transformer shapes vector group options can be specified for the primary (\IndexKey[prim]{prim=\emph{value}}), the secondary (\IndexKey[sec]{sec=\emph{value}}) and tertiary (\IndexKey[tert]{tert=\emph{value}}) three-phase vector groups: the value can be one of \IndexKey{delta}, \IndexKey{wye}, \IndexKey{eyw}\footnote{The \IndexKey{eyw} symbol was suggested by \href{https://github.com/circuitikz/circuitikz/pull/742}{Jakob Leide on GitHub}} and \IndexKey{zig}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[oosourcetrans, prim=zig, sec=delta, o-] ++(2,0)
     to[oosourcetrans, prim=delta, sec=wye,-o] ++(0,-2)
     to[ooosource, prim=eyw, sec=zig, tert=delta] (0,0)
     to[oosourceatrans, prim=wye, -*] ++(0,-2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 These two ``sources'' have additional anchors that reach the center of the symbol;\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/725}{user @lapreindl on GitHub}.} they are used sometimes to add a (symbolic) connection there, like for example a ground connection.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[european, scale=2, transform shape,
     smalldot/.style={draw, circle,red, inner sep=0.2pt}]
     \draw (0,0) to[oosourcetrans, name=A,
@@ -3052,7 +3052,7 @@ These two ``sources'' have additional anchors that reach the center of the symbo
     \node [smalldot] at (B.symbolsec) {};
     \node [smalldot] at (B.symboltert) {};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Nullator and norator}
 \label{sec:nullator-and-norator}
@@ -3066,7 +3066,7 @@ These are special elements used in some approaches to model ideal amplifiers\foo
 
 They are in the \texttt{sources} class, but they are not treated like sources in the labeling sense (they have both \texttt{bipoles/is voltage=false} and \texttt{bipoles/is current=false}, see~\ref{sec:source-vif}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) node[ground](GND){}
         to [I,l=$i_s$,invert]
@@ -3077,11 +3077,11 @@ They are in the \texttt{sources} class, but they are not treated like sources in
         to[norator, v^=$v_o$]
         (out|-GND) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The symbol shapes used here seems to be the most common in publications; if you prefer the shapes from the Wikipedia article, you can use the following definitions:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{noratorW/.style={voosource,
 		bipoles/oosource/width=0.6,
 		bipoles/oosource/height=0.3},
@@ -3089,7 +3089,7 @@ The symbol shapes used here seems to be the most common in publications; if you 
 \begin{tikzpicture}
     \draw (0,0) to[nullatorW] ++(2,0) to[noratorW] ++(0, -2);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{DC sources}\label{sec:dc-sources}
 \begin{groupdesc}
@@ -3098,7 +3098,7 @@ The symbol shapes used here seems to be the most common in publications; if you 
 \end{groupdesc}
 
 The size of the broken part of the DC current source is configurable by changing the value of \IndexKey{bipoles/dcisource/angle} (default \texttt{80}); values must be between 0 (no circle at all, probably not useful) and 90 (full circle, again not useful).
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[dcvsource] ++(2,0)
     to [dcisource, fill=yellow] ++(2,0) ;
@@ -3106,7 +3106,7 @@ The size of the broken part of the DC current source is configurable by changing
     \draw (0,-2) to[dcvsource] ++(2,0)
     to [dcisource, fill=yellow] ++(2,0) ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Sources customizations}\label{sec:tweak-sources}
 
@@ -3116,17 +3116,17 @@ You can change the scale of the batteries by setting the key \IndexKey{batteries
 
 Notice that the size of the double-circle sources (and of the triple-circle one) are tuned so that the full source occupy more or less the same horizontal space than one of the single-circle one; as a consequence, the circles are much smaller. If you want to have the same circle radius, you have to scale (locally!) those sources by one factor that is \texttt{1.5384} ($1/0.65$) for \texttt{oosource}, \texttt{1.6667} ($1/0.6$) for \texttt{oosourcetrans}, and \texttt{1.8182} ($1/0.55$) for \texttt{ooosource}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw[color=red] (0,0) to[esource] ++(3,0);
     \draw (0,0) to[oosourcetrans, prim=delta, sec=wye,
         sources/scale=1.667] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Alternatively, you can use the key \IndexKey{ootrans size} (which has possible values \texttt{small} and \texttt{large}, default \texttt{small}) to change the sizes of \texttt{oosourcetrans}, \texttt{oosourceatrans}, and \texttt{ooosource} so that they match the size of a normal source.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw[color=red] (0,2) to[esource] ++(2,0);
     \draw (0,2) to[oosourcetrans] ++(2,0)
@@ -3138,7 +3138,7 @@ Alternatively, you can use the key \IndexKey{ootrans size} (which has possible v
     to [oosourceatrans] ++(2,0)
     to [ooosource] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Waveform symbols.}
 \label{par:waveform-symbols}
@@ -3147,7 +3147,7 @@ Internal symbols of sinusoidal, triangular and square sources are drawn with the
 Normally the symbol is oriented in the same direction as the line, and rotate rigidly with the component; you can change this orientation using the key \IndexKey{sources/symbol/rotate} or \texttt{csource/...}. The default value is \texttt{90} which correspond to the ``line'' direction (remember, path components are defined as horizontal ones).
 If instead of an angle value you use \texttt{auto}, the symbol will be rotated so that the waveform is always vertical, similar to what happens in instruments:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,1) to[sqV] ++(3,0)
         to[sqV] ++(1,-1)
@@ -3158,7 +3158,7 @@ If instead of an angle value you use \texttt{auto}, the symbol will be rotated s
         to[sqV] ++(0,-3)
         to[sqV] (0,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \paragraph{Polarity symbols.}
@@ -3168,7 +3168,7 @@ The symbols drawn into the \texttt{american voltage source}\footnote{Since versi
 
 You can do the same with the \texttt{american controlled voltage sources}, substituting \texttt{cvsourceam} to \texttt{vsourceam} (notice the initial ``\texttt{c}'').
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \ctikzset{bipoles/vsourceam/inner plus={\tiny $+$}}
    \ctikzset{bipoles/vsourceam/inner minus={\tiny $-$}}
@@ -3180,7 +3180,7 @@ You can do the same with the \texttt{american controlled voltage sources}, subst
    bipoles/vsourceam/margin=0.5]
    ++(0,-3) to[short, -*] (0,0) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Orientation of the polarity symbols.}
 \label{par:orientation-of-the}
@@ -3193,7 +3193,7 @@ When rotating the sources, they usually move rigidly. This results in the fact t
 If you provide a number, the symbols are rotated by that value (\texttt{0} means that the minus sign is aligned with the wire, \texttt{90} is very similar to \texttt{default}\footnote{Not exactly equal; the position of the symbols could be slightly different depending on the font.}).
 If you use \texttt{straight}, the symbols are rotated to be always horizontal. With \texttt{auto}, the symbols are drawn in the same way as \texttt{0} for inclination less the \SI{45}{\degree}, and as \texttt{90} otherwise.The following drawing shows the results for several different parameter values.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{tikzpicture}[american, scale=0.6, transform shape]
     %\ctikzset{sources/symbol/sign rotation=default}
     \foreach \a in {0,30,...,359} \draw (0,0) -- ++(\a:1) to[V] ++(\a:2);
@@ -3204,7 +3204,7 @@ If you use \texttt{straight}, the symbols are rotated to be always horizontal. W
     \ctikzset{sources/symbol/sign rotation=straight}
     \foreach \a in {0,30,...,359} \draw (18,0) -- ++(\a:1)  to[V] ++(\a:2);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -3214,7 +3214,7 @@ The three-phase symbols \texttt{delta}, \texttt{wye}, \texttt{eyw}, and \texttt{
 the waveform ones (see above). Additionally, you can scale them up and down by changing the value of the keys
 \IndexKey{sources/symbol/delta scale}, \IndexKey[sources/symbol/wye scale]{.../wye scale}, \IndexKey[sources/symbol/eyw scale]{.../eyw scale}, and \IndexKey[sources/symbol/zig scale]{.../zig scale} (default \texttt{1}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.8, transform shape]
     \tikzset{myoosource/.style={ooosource,
         prim=wye, sec=delta, tert=zig,
@@ -3228,7 +3228,7 @@ the waveform ones (see above). Additionally, you can scale them up and down by c
     }
     \draw (0,0) to[myoosource] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Rotating the three-phase symbols.}
 \label{par:rotating-the-three}
@@ -3236,14 +3236,14 @@ You have several keys to rotate, locally or globally, the three-phase symbols\fo
 The symbols can be rotated (with effect on every symbol of that type) with the key \IndexKey{sources/symbol/delta rot} and similar ones for \texttt{eyw}, \texttt{wye} and \texttt{zig}.
 Additionally, you can rotate the symbol on a specific winding by usin the key \IndexKey{sources/symbol/prim rot} and similar ones for \texttt{sec}, \texttt{tert} and \texttt{upper}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.5, transform shape]
     \draw (0,0) to[oosourcetrans, prim=delta, sec=delta,
     sources/symbol/sec rot=180] ++(2,0);
     \draw (0,-1) to[ooosource, prim=eyw, sec=delta,
     tert=delta, sources/symbol/delta rot=180] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Source borders}
 \label{sec:source-borders}
@@ -3253,7 +3253,7 @@ The border anchors of the shapes are not tight on them (see section~\ref{sec:bip
 
 On the other hand, \TikZ{} powerful partway coordinate calculation (around section 13.5.3 of the manual) makes it possible to easily identify points on a circle if the center and one point of the circle are known, as you can see in the following example.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \path (0,0) to[oosourcetrans, name=T, ]++(2,0);
     % Use partway modifiers to reach a point on the left circle
@@ -3265,24 +3265,24 @@ On the other hand, \TikZ{} powerful partway coordinate calculation (around secti
                 ($(T.centersec)!1!\a:(T.right)$){};
     \end{scope}
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 A similar approach can be used for dependent sources. Just remember that the anchors move (rotate) together with the component.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{tikzpicture}[american]
         \draw (0,0) to [cvsource, name=S] ++(0,2);
         \node [circ,red] at ($(S.e)!0.3333!(S.n)$) {};
         \node [circ,blue] at ($(S.e)!0.6666!(S.n)$) {};
     \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Additional winding.}
 \label{par:additional-winding}
 The \texttt{oosourcetrans} and \texttt{oosourceatrans} components admit an additional winding, called \emph{upper} winding\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/886}{Jakob Leide}}.
 It can be added by specifying the key \IndexKey{oo upper winding}; you can pass an additional parameter specifying the size (relative to the symbol circle size) of the added circle. The default is \texttt{0.7}, but even the default can be changed by setting the key \IndexKey{bipoles/oosourcetrans/upper circle size default}. The height of the additional winding can be tweaked with the key \IndexKey{bipoles/oosourcetrans/upper circle offset} (default \texttt{\ctikzvalof{bipoles/oosourcetrans/upper circle offset}}, which tries to mimic the shape of \texttt{ooosource}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.5, transform shape]
     \draw (0,0) to[oosourcetrans, prim=delta, o-o, name=a,
         sources/symbol/delta rot=180,
@@ -3294,13 +3294,13 @@ It can be added by specifying the key \IndexKey{oo upper winding}; you can pass 
     \draw (0,-1) to[oosourcetrans, oo upper winding=1
         ] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Additional winding anchors.}
 \label{par:additional-winding-anchors}
 When using the upper winding, you have several additional anchors available.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.5, transform shape,
     smallsquare/.style={red, draw, inner sep=1pt}]
     \draw (0,0) to[oosourcetrans, oo upper winding=0.85,
@@ -3311,9 +3311,9 @@ When using the upper winding, you have several additional anchors available.
         \draw[red] (a.\anc) node[smallsquare]{} -- ++(\ang:0.5)
             ++(\ang:0.1) node[font=\tiny\ttfamily,]{\anc};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.5, transform shape,
     smallsquare/.style={red, draw, inner sep=1pt}]
     \draw (0,0) to[oosourceatrans, oo upper winding=0.75,
@@ -3324,7 +3324,7 @@ When using the upper winding, you have several additional anchors available.
         \draw[red] (a.\anc) node[smallsquare]{} -- ++(\ang:0.5)
             ++(\ang:0.1) node[font=\tiny\ttfamily,]{\anc};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Instruments}
 \label{sec:instruments}
@@ -3342,7 +3342,7 @@ When using the upper winding, you have several additional anchors available.
 You can define styles if you want to use the new shapes for round instrument similarly to the legacy ones:%
 \footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/787}{user mxxmxn on GitHub}.}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{vmeter/.style={rmeterwa, t=V}}
 \tikzset{ameter/.style={rmeterwa, t=A}}
 \tikzset{ometer/.style={rmeterwa, t=$\Omega$}}
@@ -3357,7 +3357,7 @@ You can define styles if you want to use the new shapes for round instrument sim
         to[ameter] ++(2,0)
         to[ometer] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Square instruments}
 \label{sec:square-instruments}
@@ -3406,7 +3406,7 @@ You can change the inner dot in several way, by changing the following keys unde
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,2) to[currtap, bipoles/currtap/fill=none, *-]
         ++(2,0) to[currtap, bipoles/currtap/.cd,
@@ -3417,7 +3417,7 @@ You can change the inner dot in several way, by changing the following keys unde
         bipoles/currtap/dot size=0.3] ++(2,0);
     \draw (ct.tap) -- ++(0,-1) (ct2.tap) -- ++(0,-1);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Square instruments index position.} You can change the index position of square
 \label{par:square-instruments-index}
@@ -3425,7 +3425,7 @@ instruments with the key \IndexKey{bipoles/smeter/index position} (for \texttt{s
 \IndexKey{bipoles/qmeter/index position} (for \texttt{qiprobe}, \texttt{qvprobe} and \texttt{qpprobe}).
 Use a value between \texttt{0} and \texttt{100} (the default is \texttt{80}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
   % Default
   \foreach [count=\i] \inst in
@@ -3442,12 +3442,12 @@ Use a value between \texttt{0} and \texttt{100} (the default is \texttt{80}).
         ({1.5*(\i+1)},0);
   }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Oscilloscope waveform.} You can change the waveform shown in the oscilloscope ``screen''\footnote{Suggested by \href{https://tex.stackexchange.com/q/595062/38080}{Mario Tafur on TeX.SX}}. To change it, you just set the key \IndexKey{bipoles/oscope/waveform} to one of the available shape. You have available the shapes in the following list (the default is \texttt{ramps}):
 \label{par:oscilloscope-waveform}
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \begin{circuitikz}
     \foreach [count=\i] \wvf in {ramps, sin, square, triangle, lissajous, zero, none} {
         \ctikzset{bipoles/oscope/waveform=\wvf}
@@ -3460,11 +3460,11 @@ Use a value between \texttt{0} and \texttt{100} (the default is \texttt{80}).
         \draw ({2*\i},0) node[oscopeshape]{};
     }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you want more or different shapes, you can define your owns, but you have to use low-level \texttt{pgf} commands (see part IX, ``The Basic Layer'', in the PGF/\TikZ{} manual). The code is executed into a \verb|\pgfscope| \dots \verb|\endpgfscope| environment, and it must use the path built with a \verb|\pgfusepath|. The coordinates have been scaled so that the external box of the scope is a rectangle between \texttt{(-1cm, -1cm)} and \texttt{(1cm, 1cm)}; the oscilloscope grid is fixed and painted between \texttt{(-0.75cm, -0.5cm)} and \texttt{(0,75cm, 0.5cm)}. If you stretch the scope with the \texttt{\dots width} or \texttt{\dots height} keys, the drawing will be stretched too.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \ctikzset{%
     bipoles/oscope/waveform/mywave/.code={%
         \pgfsetcolor{red}
@@ -3480,7 +3480,7 @@ If you want more or different shapes, you can define your owns, but you have to 
         \ctikzset{bipoles/oscope/waveform=mywave}
         \draw (0,0) node[oscopeshape]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -3489,20 +3489,20 @@ If you want more or different shapes, you can define your owns, but you have to 
 
 The \texttt{oscope} element will not rotate the ``graph'' shown with the component:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \foreach \a in {0,45,...,350} {
         \draw (0,0) to[oscope] (\a:3);
     }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \texttt{rmeter}, \texttt{rmaterwa}, and \texttt{smeter} have the same behavior.
 
 However, if you prefer that the \texttt{oscope}, \texttt{rmeter}, \texttt{smeter}  and \texttt{rmeterwa} instruments rotate the text or the diagram,
 you can use the key or style \IndexKey{rotated instruments} (the default style is \IndexKey{straight instruments}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}[scale=0.8, transform shape]
     \ctikzset{rotated instruments} % new default
     \draw (0,0) to[oscope] ++(0:3);
@@ -3515,7 +3515,7 @@ you can use the key or style \IndexKey{rotated instruments} (the default style i
     % local override
     \draw (0,0) to[smeter, t=A, rotated instruments] ++(300:3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -3525,7 +3525,7 @@ you can use the key or style \IndexKey{rotated instruments} (the default style i
 The node-style usage of the \texttt{oscope} is also interesting, using the additional \texttt{in 1} and \texttt{in 2} anchors; notice that in this case you can use the text content of the node to put labels above it.
 Moreover, you can change the size of the oscilloscope by changing \IndexKey{bipoles/oscope/width} and \IndexKey{bipoles/oscope/height} keys (which both default to 0.6).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,1)
         to[oscope=$C_1$, fill=green!20!gray, name=O1] ++(2,0);
@@ -3538,25 +3538,25 @@ Moreover, you can change the size of the oscilloscope by changing \IndexKey{bipo
     \draw (O2.in 1) to[short, *-] ++(0,-0.5)
            -- ++(-1,0) node[currarrow, xscale=-1]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Measuring voltage and currents, multiple ways}
 \label{sec:measuring-voltage-and}
 
 This is the classical (legacy) option, with the \texttt{voltmeter} and \texttt{ammeter}. The problem is that elements are intrinsically horizontal, so they look funny if put in vertically.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [ammeter] ++(0,-2) node[ground]{};
     \draw (1,0) to[voltmeter] ++(0,-2)
     node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 So the solution is often changing the structure to keep the meters in horizontal position.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [ammeter] ++(2,0) --
@@ -3564,22 +3564,22 @@ So the solution is often changing the structure to keep the meters in horizontal
     \draw (1,0) -- (1,1) to[voltmeter]
     ++(2,0) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since version 0.9.0 you have more options for the measuring instruments. You can use the generic \texttt{rmeterwa} (round meter with arrow), to which you can specify the internal symbol with the option \texttt{t=...} (and is fillable).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [rmeterwa, t=A, i=$i$] ++(0,-2) node[ground]{};
     \draw (1,0) to[rmeterwa, t=V, v=$v$] ++(0,-2)
     node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This kind of component will keep the symbol horizontal, whatever the orientation:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [rmeterwa, t=A, i=$i$] ++(2,0) --
@@ -3587,44 +3587,44 @@ This kind of component will keep the symbol horizontal, whatever the orientation
     \draw (1,0) -- (1,1) to[rmeterwa, t=V, v^=$v$]
     ++(2,0) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The plain \texttt{rmeter} is the same, without the measuring arrow:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [rmeter, t=A, i=$i$] ++(0,-2) node[ground]{};
     \draw (1,0) to[rmeter, t=V, v=$v$] ++(0,-2)
     node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you prefer it, you have the option to use square meters, in order to have more visual difference from generators:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [smeter, t=A, i=$i$] ++(0,-2) node[ground]{};
     \draw (1,0) to[smeter, t=V, v=$v$] ++(0,-2)
     node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Another possibility is to use QUCS\footnote{QUCS is an open source circuit simulator: \url{http://qucs.sourceforge.net/}}-style probes, which have the nice property of explicitly showing the type of connection (in series or parallel) of the meter:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(2,0)
     to [qiprobe, l=$i$] ++(0,-2) node[ground]{};
     \draw (1,0) to[qvprobe, l=$v$] ++(0,-2)
     node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you want to explicitly show a power measurement, you can use the power probe \texttt{qpprobe} and using the additional anchors \texttt{v+} and \texttt{v-} :
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[short,-*]  ++(1,0) coordinate(b)
     to[R] ++(2,0) to [qpprobe, l=$i$, a=$v$, name=P]
@@ -3633,11 +3633,11 @@ If you want to explicitly show a power measurement, you can use the power probe 
     to [short, -*] (a-|GND);
     \draw (P.v+) -| (b);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The final possibility is to use oscilloscopes.  For example:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(3,0)
     to [iloop, mirror, name=I] ++(0,-2)
@@ -3647,11 +3647,11 @@ The final possibility is to use oscilloscopes.  For example:
     \draw (I.i) -- ++(-0.5,0) node[oscopeshape, anchor=right, name=O]{};
     \draw (O.south) -- (O.south |- GND) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Or, if you want a more physical structure for the measurement setup:
 
-\begin{LTXexample}[varwidth=true, pos=b]
+\begin{ctikzExample}[varwidth=true, pos=b]
 \begin{circuitikz}[american]
     \draw (0,0) -- ++(1,0) to[R] ++(3,0) to [iloop2, name=I] ++(0,-2)
     node[ground] (GND){};
@@ -3663,7 +3663,7 @@ Or, if you want a more physical structure for the measurement setup:
     \draw (bnc2.hot) |- (I.i+);
     \draw (I.i-) node[ground, scale=0.5]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Mechanical Analogy}
@@ -3741,7 +3741,7 @@ If otherwise \IndexKey{americangfsurgearrester} option is active (or the style \
 
 You can use microphones and loudspeakers with \texttt{waves} (see section~\ref{sec:RF}) too:
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \draw (0,0) to[mic, name=M] ++(0,2)
         to[amp, t=$A$] ++(2,0)
@@ -3752,19 +3752,19 @@ You can use microphones and loudspeakers with \texttt{waves} (see section~\ref{s
         \node [waves, scale=0.7, right]
             at(L.north) {};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 You have two types of microphones; \texttt{mic} has protruding connection and \texttt{tlmic} (for tail-less microphone) is inline. This last one is handy for use as a separate shape (which is named \texttt{tlmicshape}). You can change the (relative) thickness of the straight bar using the key \IndexKey{bipoles/mic/bar thickness} (default \texttt{1}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,2) to[mic, name=M] ++(2,0) to[tlmic] ++(2,0);
     \node [color=red, tlmicshape](T) at (M.center) {};
     \ctikzset{bipoles/mic/bar thickness=3}
     \draw (0,0) to[mic] ++(2,0) to[tlmic] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Miscellaneous element customization}\label{sec:tweak-misc}
 
@@ -3774,7 +3774,7 @@ You can change the scale of all the miscellaneous elements by setting the key \I
 \label{par:wiggly-fuses}
 The pole nodes are named \texttt{-left} and \texttt{-right} so that you can access their borders.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,3) to[wfuse, bipoles/wfuse/dots=false] ++(2,0);
     \draw (0,2) to[wfuse, name=A] ++(2,0);
@@ -3785,21 +3785,21 @@ The pole nodes are named \texttt{-left} and \texttt{-right} so that you can acce
     \ctikzset{bipoles/wfuse/shape=circ}
     \draw (0,0) to[wfuse, name=B] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Neon lamps.} Neon lamp ``dot'' size is the same as the size of poles (\texttt{circ} and \texttt{ocirc}), and they can be changed locally:
 \label{par:neon-lamps}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \draw (0,0) to[neonlampcc, nodes width=0.03] ++(2,0)
         to[neonlampac, misc/thickness=3] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Spark gap.} The \texttt{sparkgap} component is similar to the (American) surge arrester, but it's more configurable; it will render bare (unenclosed) by default, but you can add a (fillable) enclosure with the key \IndexKey{sparkgap/circle} and a dot with \IndexKey{sparkgap/dot} (they are boolean keys, false by default).
 \label{par:spark-gap}
 Moreover, the arrows are configurable like other arrows in the package (see~\ref{sec:tunablearrows}) using the \IndexKey{sparkgap end arrow} key (default \texttt{Triangle[scale=2]}). The gap is tunable with \IndexKey{sparkgap/gap} (default \texttt{0.05}).
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \draw (0,2) to[sparkgap, l=gap\textsubscript{1}] ++(2,0)
          to[sparkgap, sparkgap/circle,
@@ -3809,7 +3809,7 @@ Moreover, the arrows are configurable like other arrows in the package (see~\ref
          to[sparkgap, l=S4, sparkgap/circle,
          sparkgap/gap=0.15] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 As in neon lamps, the dot (if activated by the key \texttt{sparkgap/dot}) follows the size of poles and can be changed locally.
 
 \subsubsection{Miscellaneous symbols}
@@ -3822,7 +3822,7 @@ As in neon lamps, the dot (if activated by the key \texttt{sparkgap/dot}) follow
 
 The symbols for dc or ac voltages or currents can be useful to specify the waveforms in parts of the circuit, or to add to existing symbols.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \draw (0,1.5) to[generic, name=a] ++(2,0);
     \node [ac symbol] at (a.center) {};
@@ -3830,7 +3830,7 @@ The symbols for dc or ac voltages or currents can be useful to specify the wavef
     \draw (1,0) node[dc symbol, dc symbol segments=1]{\qty{1}{\uA}};
     \draw (2,0) node[dc symbol, dc symbol segments=4]{$V_p$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Customization of ac/dc symbols.}
 \label{sec:customization-of-ac}
@@ -3842,7 +3842,7 @@ As shown in the example above, the \texttt{dc symbols} has an additional options
 
 Additionally, you can change the relative thickness of the bottom line with the key \texttt{dc symbols/relative thickness} (default \texttt{1}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{tikzpicture}[scale=2, transform shape]
     \tikzset{my dc symbol/.style={
         dc symbol,
@@ -3858,7 +3858,7 @@ Additionally, you can change the relative thickness of the bottom line with the 
         circuitikz/misc/thickness=4] at (A.north) {};
     \node [my dc symbol, above] at (V.north) {};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Multiple wires (buses)}
 \label{sec:multiple-wires-buses}
@@ -3871,13 +3871,13 @@ These are simple drawings to indicate multiple wires.
 \footnotetext{added by \texttt{olfline}}
 \end{groupdesc}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[multiwire=4] ++(1,0);
     \draw (0,-2) to[bmultiwire=6] ++(1,0);
     \draw (0,-4) to[tmultiwire=3] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -3898,7 +3898,7 @@ Node style:
 
 All circuit-drawing standards agree that to show a crossing without electric contact, a simple crossing of the wires suffices; the electrical contact must be explicitly marked with a filled dot.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
 \draw(1,-1) to[short] (1,1)
     (0,0) to[short] (2,0);
@@ -3906,23 +3906,23 @@ All circuit-drawing standards agree that to show a crossing without electric con
     (3,0) to[short] (5,0)
     (4,0) node[circ]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 However, sometimes it is advisable to mark the non-contact situation more explicitly. To this end, you can use a path-style component called \texttt{crossing}:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
 \draw(1,-1) to[short] (1,1) (0,0) to[crossing] (2,0);
 \draw(4,-1) to[short] (4,1) (3,0) to[short] (5,0)
     (4,0) node[circ]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 That should suffice most of the time; the only problem is that the crossing jumper will be put in the center of the subpath where the \texttt{to[crossing]} is issued, so sometimes a bit of trial and error is needed to position it.
 
 For a more powerful (and elegant) way you can use the crossing nodes:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \node at (1,1)[jump crossing](X){};
     \draw (X.west) -- ++(-1,0);
@@ -3930,7 +3930,7 @@ For a more powerful (and elegant) way you can use the crossing nodes:
     \draw (X.north) node[vcc]{};
     \draw (X.south) to[C] ++(0,-1.5);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the \texttt{plain crossing} and the \texttt{jump crossing} have a small gap in the straight wire, to enhance the effect of crossing (as a kind of shadow).
 
@@ -3954,7 +3954,7 @@ While the horizontal line will be drawn with the current path values, you can ch
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}[every node/.append style={scale=2}]
         \draw (0,2) node[jump crossing](A){};
         \begin{scope}
@@ -3964,7 +3964,7 @@ While the horizontal line will be drawn with the current path values, you can ch
         \ctikzset{crossing vertical/dash=none}
         \draw[densely dotted, blue] (0,0) node[plain crossing](B){};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Arrows (fake and real)}\label{sec:arrows}
 
@@ -3981,7 +3981,7 @@ The main arrow shapes in \Circuitikz{} are really shapes, used as pseudo-arrows 
 
 You can use the parameter  \IndexKey{current arrow scale} to change the size of the arrows in various components and indicators; the normal value is 16, higher numbers give smaller arrows and so on.  You need to use  \texttt{circuitikz/current arrow scale} if you use it into a node.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R, i=f] ++(2,0) node[npn, anchor=B]{};
     \draw (0,-2) to[R, f=f, current arrow scale=8] ++(2,0)
@@ -3989,15 +3989,15 @@ You can use the parameter  \IndexKey{current arrow scale} to change the size of 
     \draw (0,-4) to[R, f=f, current arrow scale=24] ++(2,0)
             node[nigbt, anchor=B]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Moreover, you have the arrow tip \IndexKey{latexslim} which is an arrow similar to the old (in deprecated \texttt{arrows} library) \texttt{latex'} element:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american,]
     \draw [latexslim-latexslim] (0,0) -- (1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Generic Tunable Arrows}
 \label{sec:generic-tunable-arrows}
@@ -4011,7 +4011,7 @@ where \emph{extra options} is an optional argument with generic \TikZ{} keys, \e
 
 The arrows are the ones set with the keys \IndexKey{tunable start arrow} and \IndexKey{tunable end arrow} (to maintain coherency across the circuit), but you can override them in the \emph{extra options} argument as shown in the following example.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[tlground]{} to[sV, name=A] ++(0,3)
         node[op amp, anchor=+](B){};
@@ -4025,7 +4025,7 @@ The arrows are the ones set with the keys \IndexKey{tunable start arrow} and \In
         \ctikztunablearrow[red, shorten <=3mm]{6}{0.8}{110}{B}
     \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice also the need to force a transparency group if you want a semitransparent arrow.
 
@@ -4037,7 +4037,7 @@ The package automatically loads the \texttt{arrows.meta} \TikZ{} library but \em
 The other tip is \IndexKey{Jack Tap}\footnote{Added after a suggestion from \href{https://github.com/circuitikz/circuitikz/issues/806}{Anisio Rogerio Braga} on GitHub}, which is mainly used to build jack connectors (see section~\ref{sec:jacks}). This is a new-style arrow tip, and accepts the parameter \texttt{length} (default \texttt{0.3 cm}), \texttt{width} (default \texttt{0.15 cm}), and the boolean \texttt{swap}.
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,.25) (0,0) edge[-latexslim] ++(1,0)
     ++(0, -0.5) edge[-{Jack Tap[swap]}] ++(1,0)
@@ -4049,7 +4049,7 @@ The other tip is \IndexKey{Jack Tap}\footnote{Added after a suggestion from \hre
     ++(0, -0.5) edge[^-^f] ++(1,0)
     ++(0, -0.5) edge[vf-v] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 You can also have a filled version, by adding the key \texttt{fill} (without arguments\footnote{This usage of the \texttt{fill} key in arrow tips will be added to \TikZ{} in version \texttt{3.1.11}, see \href{https://github.com/pgf-tikz/pgf/pull/1352}{this PR by Henri Menke}; \Circuitikz{} will add it to older versions.}) or \texttt{fill=color} if you want a color different from the stroke ones, and they accept the \texttt{line join} and \texttt{line cap} as most of the standard \TikZ{} arrows.
 As you can see, the normal and swapped \texttt{Jack Tap} tips have the shorthands \texttt{v} and \verb|^| (and \texttt{vf} and \verb|^f| for their filled counterparts). Notice that the tips are automatically reversed when they are at the \emph{start} of the path.
 
@@ -4074,12 +4074,12 @@ This is not a pole, but it's used to "fill" nasty corners (look closer, and see 
 
 Since version 0.9.0, ``bipole nodes'' shapes have all the standard geographical anchors, so you can do things like these:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american,]
     \draw (0,-1) node[draw](R){R};
     \draw (R.east) node[ocirc, right]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The size of the poles is controlled by the key \IndexKey{nodes width} (default \texttt{0.04}, relative to the basic length).
 Be sure to see section~\ref{sec:bipole-nodes} for more usage and configurability.
@@ -4096,7 +4096,7 @@ Connectors have a class by themselves (\IndexKey[connectors/scale]{connectors}),
 \end{groupdesc}
 The BNC connector is defined so that you can easily connect it as input or output (but remember that you need to flip the text if you flip the component):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0)
     node[bnc](B1){$v_i$} to[R=\SI{50}{\ohm}] ++(3,0)
@@ -4105,17 +4105,17 @@ The BNC connector is defined so that you can easily connect it as input or outpu
     \node [ground] at (B1.shield) {};
     \node [eground] at (B2.shield){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 It also has a \texttt{zero} anchor if you need to rotate it about its real center.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw[thin, red] (0,0) -- ++(1,0) (0,-1) -- ++(1,0);
     \path (0,0) node[bnc]{} ++(1,0) node[bnc, rotate=-90]{};
     \path (0,-1) node[bnc, anchor=zero]{} ++(1,0) node[bnc, anchor=zero, rotate=-90]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{IEC 60617 socket-plug connectors}
 \label{sec:iec-60617-socket}
@@ -4138,18 +4138,18 @@ Also, the text for the plug nodes is raised to the same level of the text in the
 
 The \texttt{plug center} anchor always point to the center of the rectangular plug shape, and the \texttt{socket center} to the center of the semicircle in the sockets.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,1) node[bnc]{} to[R] ++(2,0)
         to[iec connector] ++(1,0);
     \draw (0,0) node[bnc]{} to[R] ++(2,0)
         to[iec connector, invert] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Aligning ``disconnected'' plugs and sockets is reasonably easy:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,2) to[iec connector, name=C1] ++(2,0) coordinate(stop)
         (C1.nw) node[above left, inner xsep=0pt]{s1}
@@ -4160,20 +4160,20 @@ Aligning ``disconnected'' plugs and sockets is reasonably easy:
         node[iecplugR](P3){p3} (P3.right) -- (tmp-|stop);
     \draw[red, dashed] ([yshift=1cm]C1.socket center) -- ++(0,-4);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can choose the best shape when rotating them, to simplify the positioning (shape rotates around the \texttt{center} anchor).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) -| ++(1,-1) node[iecsocketL, rotate=-90]{}
         (2,-1) -| ++(1,1) node[iecplugR, rotate=90]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Choosing the proper left/right shape results in easily build ``mixed'' connectors; you can use the node text position properties to have lined-up labels, but remember that the text is outside the bounding box:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \path (0,2); % for the bounding box, text is not accounted for
     \draw (0,1)--++(1,0) node[iecsocketL](s1){S1};
@@ -4181,17 +4181,17 @@ Choosing the proper left/right shape results in easily build ``mixed'' connector
     \draw (0,0) -- ++(1,0) node[iecplugL](p2){P2};
     \draw [color=blue](p2.e) node[iecsocketR](s2){S2} (s2.e)--++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use the \texttt{plug center} anchor to add the IEC ``multiplier'':
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) to[iec connector, connectors/scale=2, name=A,
         a={\small\ttfamily output bus}] ++(3,0);
     \draw (A.plug center) ++(-.2,-.4) -- ++(.4,.8) node[above]{8};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Jack connectors}\label{sec:jacks}
 
@@ -4199,7 +4199,7 @@ There are \emph{lots} of different jack connectors symbols --- see the \href{htt
 
 For example, and audio jack can be drawn like this:
 
-\begin{LTXexample}[pos=t, varwidth=true]
+\begin{ctikzExample}[pos=t, varwidth=true]
 % drawing based on one by Anisio Rogerio Braga
 % https://github.com/circuitikz/circuitikz/issues/806
 \newcommand\dx{1.5}\newcommand\dy{1}
@@ -4218,7 +4218,7 @@ For example, and audio jack can be drawn like this:
     \draw[-^] (0,\dy/3) to[short, o-] ++(2*\dx/3,-0.2);
     \draw (0,0.0) to[short, o-] ++(1.75*\dx,0) rectangle ++(0.2,4*\dy/3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Block diagram components}
 \label{sec:block-diagram-components}
@@ -4345,7 +4345,7 @@ Blocks to draw TV/radio system schematics, contributed by \href{https://github.c
 
 The ports of the \texttt{mixer}, \texttt{adder}, \texttt{oscillator} and \texttt{circulator}  can be addressed with \texttt{west}, \texttt{south}, \texttt{east}, \texttt{north}; the equivalent \texttt{left}, \texttt{down}, \texttt{right}, \texttt{up};  or the shorter \texttt{w, s, e, n} ones:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[mixer] (mix) {}
   (mix.w) node[left] {w}
@@ -4353,10 +4353,10 @@ The ports of the \texttt{mixer}, \texttt{adder}, \texttt{oscillator} and \texttt
   (mix.e) node[right] {e}
   (mix.n) node[above] {n}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In addition, since \texttt{v1.6.0},  most blocks also have the \texttt{left up}, \texttt{left down}, \texttt{right up} and \texttt{right down} anchors:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
     (0,0) to[bandpass, name=bp] ++(2,0)
     (bp.left up) node[circ, red]{}
@@ -4364,12 +4364,12 @@ In addition, since \texttt{v1.6.0},  most blocks also have the \texttt{left up},
     (bp.right up) node[circ, green]{}
     (bp.right down) node[circ, orange]{}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since \texttt{1.6.7} you can change the relative position of the lateral generic anchors\footnote{Suggested by \href{https://github.com/circuitikz/circuitikz/issues/769}{user @sputeanus} on GitHub} using the keys \IndexKey{block left anchors pos} and \IndexKey{block right anchor pos} (default \texttt{0.5}, as in previous releases) which set the position as a fraction of the top to center segment.
 Since \texttt{1.8.4} the effect of this keys is also extended to node-type blocks, which is especially useful for the ``boxed'' versions; you can also use the inner styling here.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{block left anchors pos=0.8, block right anchors pos=0.2}
     \ctikzset{blocks/inner thickness=3, blocks/inner color=orange}
@@ -4381,11 +4381,11 @@ Since \texttt{1.8.4} the effect of this keys is also extended to node-type block
         (\n.right up) node[circ, green]{}
         (\n.right down) node[circ, orange]{};}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 To set both left and right at the same value, you can use the key \IndexKey{block lateral anchors pos}, which set both to the same number.
 You can use those anchors to build ``mixed-type'' circuits, using the node-shapes (the following drawing is a bit silly, but shows that the anchor position can be changed locally):
-\begin{LTXexample}[pos=t, varwidth=true]
+\begin{ctikzExample}[pos=t, varwidth=true]
 \begin{tikzpicture}[
     big/.style={circuitikz/blocks/scale=1.5},
     long/.style={circuitikz/bipoles/twoportsplit/width=1.5}]
@@ -4394,43 +4394,43 @@ You can use those anchors to build ``mixed-type'' circuits, using the node-shape
         (5,0) node[twoportsplitshape, big, long, t1=LNA, t2=Digital](B){};
     \draw (A.right up) -- (B.left up) (A.right down) to[cute choke] (B.left down);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice also from the previous example that the generic blocks (\IndexKey[twoport/width]{twoport} and \IndexKey[twoportsplit/width]{twoportsplit}) can be made ``longer'' by setting different \texttt{width} and \texttt{height} (the other blocks are square, and just use the \texttt{width} key for both dimensions).
 
 Also, for \texttt{amp} and \texttt{vamp}, the \texttt{up} and \texttt{down} anchors follow the shape when they are not boxed.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \draw (0,0) to[vamp, name=a] ++(1.5,0)
         to [vamp, boxed, name=ab] ++(1.5,0);
     \path (a.up) node[circ, blue]{} (ab.up) node[circ, blue]{};
     \path (a.down) node[circ, red]{} (ab.down) node[circ, red]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \texttt{oscillator} has a displaced \texttt{center} anchor, to simplify the task of putting it at the left side of a circuit; it also as a special position for the node text. The four round elements (mixer, circulator, adder, and the oscillator) have a \texttt{geocenter} anchor which always corresponds to the center of the circle.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[>=Stealth]
     \draw (0,0)node[oscillator](O){$f_0$} -- ++(1,0);
     \draw[blue, ->] (1,1) -- (O.center);
     \draw[red, ->] (1,1) -- (O.geocenter);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Moreover, the have proper border anchors since version \texttt{1.2.3} (and fixed for boxed elements in \texttt{1.5.0}), so you can do things like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
   \draw (0,0) node[adder] (mix) {}
   (-1,1) -- ++(0.5,0) -- (mix)
   (-1,-1) -- ++(0.5,0) -- (mix) -- ++(1,0);
   \draw [red, <-] (mix.45) -- ++(1,1);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Those components have also \textbf{deprecated} anchors named \texttt{1, 2, 3, 4}; they are better not used because they can conflict with the border anchor. They still work for backward compatibility, but could be removed in a future release.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[mixer] (mix) {}
   (mix.1) node[left] {1} (mix.2) node[below] {2}
@@ -4439,11 +4439,11 @@ Those components have also \textbf{deprecated} anchors named \texttt{1, 2, 3, 4}
   (-1,-1)--(1,1)(-1,1)--(1,-1);
 \node [red, below] at (0,-1) {DON'T USE};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The Wilkinson divider has (notice that the node text is outside the bounding box, similarly to what happens for transistors!):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[wilkinson] (w) {\SI{3}{dB}}
   (w.in) to[short,-o] ++(-0.5,0)
@@ -4454,11 +4454,11 @@ The Wilkinson divider has (notice that the node text is outside the bounding box
   (w.out2) node[above right] {\texttt{out2}}
   ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The couplers have:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw (0,1.5) %bounding box
   (0,0) node[coupler] (c) {\SI{10}{dB}}
   (c.left down) to[short,-o] ++(-0.5,0)
@@ -4471,11 +4471,11 @@ The couplers have:
   (c.left up) node[above left] {\texttt{left up}}
   ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Or you can also use \texttt{port1} to \texttt{port4} if you prefer:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw (0,1.5) %bounding box
   (0,0) node[coupler2] (c) {\SI{3}{dB}}
   (c.port1) to[short,-o] ++(-0.5,0)
@@ -4488,11 +4488,11 @@ Or you can also use \texttt{port1} to \texttt{port4} if you prefer:
   (c.port4) node[above left] {\texttt{port4}}
   ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Also they have the simpler \texttt{1, 2, 3, 4} anchors, and although they have no border anchors (for now), it is better not to use them.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw(0,1.5) %bounding box
   (0,0) node[coupler] (c) {\SI{10}{dB}}
   (c.1) to[short,-o] ++(-0.5,0)
@@ -4505,7 +4505,7 @@ Also they have the simpler \texttt{1, 2, 3, 4} anchors, and although they have n
   (c.4) node[above left] {\texttt{4}}
   ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Blocks customization}
 \label{sec:blocks-customization}
@@ -4513,19 +4513,19 @@ Also they have the simpler \texttt{1, 2, 3, 4} anchors, and although they have n
 You can change the scale of all the block elements by setting the key \texttt{blocks/scale} to something different from the default \texttt{1.0}.
 
 With the option \texttt{>} you can draw an arrow to the input of the block diagram symbols.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[short,o-] ++(0.3,0)
   to[lowpass,>] ++(2,0)
   to[adc,>] ++(2,0)
   to[short,-o] ++(0.3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 You can also change the width for the generic block:
 
-\begin{LTXexample}[pos=t, varwidth=t]
+\begin{ctikzExample}[pos=t, varwidth=t]
 \begin{circuitikz}[european]
     \draw (0,0) to[amp, >, t=$K_{\mathrm{p}}$] ++(2,0)
     to[saturation, >, name=sat] ++(2,0) -- ++(0.5,0)
@@ -4534,13 +4534,13 @@ You can also change the width for the generic block:
     \node[above] at (sat.ne) {$+I_{\mathrm{max}}$};
     \node[below] at (sat.sw) {$-I_{\mathrm{max}}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Multi ports}
 \label{par:multi-ports}
 Since inputs and outputs can vary, input arrows can be placed as nodes. Note that you have to rotate the arrow on your own:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[mixer] (m) {}
   (m.w) to[short,-o] ++(-1,0)
@@ -4549,11 +4549,11 @@ Since inputs and outputs can vary, input arrows can be placed as nodes. Note tha
   (m.w) node[inputarrow] {}
   (m.s) node[inputarrow,rotate=90] {};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use additional anchors to mix different kinds of elements.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 % Author: Prof. Dr. Matthias Jung Year: 2023
 \begin{tikzpicture}
     %\useasboundingbox (-3.75,-1.0) rectangle (10.5,3);
@@ -4570,13 +4570,13 @@ You can use additional anchors to mix different kinds of elements.
     \draw(supply.u2) to [short, -o] ++(-1,0) coordinate(c2);
     \draw(c1) to [open, l_={$\sim\qty{230}{\volt}$}] (c2);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Labels and custom two-port boxes}
 \label{par:labels-and-custom}
 
 You can use the keys \texttt{t}, \texttt{t1}, \texttt{t2} (shorthands for \texttt{text}, \texttt{text in}, \texttt{text out}) to fill the generic blocks:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[short,o-] ++(0.3,0)
   to[allpass,>] ++(2,0)
@@ -4584,30 +4584,30 @@ You can use the keys \texttt{t}, \texttt{t1}, \texttt{t2} (shorthands for \textt
   to[twoportsplit,t1={\tiny in},
     t2={\tiny\color{red}out}] ++(0,-2.5);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Some two-ports have the option to place a normal label (\texttt{l=}) and a inner label (\texttt{t=}).
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
   \ctikzset{bipoles/amp/width=0.9}
   \draw (0,0) to[amp,t=LNA,l_=$F{=}0.9\,$dB,o-o] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Each block determines where the text is added:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[qgenerator, t=G,*-] ++(2,0)
   to[vallpass,>] ++(2,0)
   to[ngenerator, t=FM,>] ++(2,0)
   to[short,-o] ++(0.3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Box option}
 \label{par:box-option}
 Several devices have the possibility to add a box around them with the \IndexKey{box} or \IndexKey{boxed} option. The inner symbol scales down to fit inside the box. For the ``circled'' devices (mixer, adder, oscillator and circulator) the inner circle is normally drawn, unless you use the \IndexKey{box only} or \IndexKey{boxed only} option.\footnote{Since 1.5.0, suggested by \href{https://github.com/circuitikz/circuitikz/issues/621}{GitHub user myzinsky}}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[mixer, box only, anchor=east](m){}
     to[amp, boxed, >, -o] ++(2.5,0)
@@ -4615,14 +4615,14 @@ Several devices have the possibility to add a box around them with the \IndexKey
   (m.south) node[inputarrow,rotate=90]{} --
     ++(0,-0.7) node[oscillator, box, anchor=north]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \paragraph{Dash optional parts}
 \label{par:dash-optional-parts}
 To show that a device is optional, you can dash it. The inner symbol will be kept with solid lines, unless you set the key \IndexKey{inner blocks dashed} to true.
 Moreover, the key \IndexKey{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|), be careful with the number of braces!.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,1.5) to[amp,l=\SI{10}{dB}] ++(2.5,0);
 \draw[dashed] (2.5,1.5) to[lowpass,l=opt.] ++(2.5,0);
@@ -4636,7 +4636,7 @@ Moreover, the key \IndexKey{dashed blocks pattern} (default \verb|{{1mm}{1mm}}|)
 \draw (0,-1.5) to[amp,l=\SI{10}{dB}] ++(2.5,0)
      to[lowpass,l=opt., dashed] ++(2.5,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Dashing the DC symbol in blocks.}
 \label{par:dashing-the-dc}
@@ -4645,7 +4645,7 @@ Moreover, sometimes the dashing is used to convey different meanings (like recti
 You can change the general style for the DC symbol using the key \IndexKey{blocks dc segments}; using~\texttt{1} (default) will use a continuous line; using \texttt{2} you will have the international-styled symbol, and with~\texttt{3} the English one (you can use higher numbers; the only restriction is that it must be strictly greater than \texttt{0}).  You can also change the input and output part separately with the keys \IndexKey{blocks dc in segments} and \IndexKey{blocks dc out segments} (see the following example). The \texttt{inner blocks dashed} can have strange interaction with these ones.
 
 
-\begin{LTXexample}[basicstyle=\footnotesize\ttfamily]
+\begin{ctikzExample}[basicstyle=\footnotesize\ttfamily]
 \begin{tikzpicture}[scale=0.8]
     \ctikzset{blocks dc segments=3}
     \draw (0,2) to[sacdc] ++(2,0) to[sdcdc]
@@ -4657,14 +4657,14 @@ You can change the general style for the DC symbol using the key \IndexKey{block
             dashed blocks pattern={{0.4pt}{0.4pt}}]
         ++(2,0) to[sdcac] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \paragraph{Blocks inner drawing.}
 \label{par:blocks-inner-drawing}
 Almost all of the inner block drawing style can be customized, without affecting the external box, with the keys \IndexKey{blocks/inner color} (default \texttt{default}, which means ``don't change color'') and \IndexKey{blocks/inner thickness} (default \texttt{1}; this is relative to the class-specified thickness).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[short,o-] ++(0.3,0)
   to[lowpass,>, blocks/inner color=red ] ++(2,0)
@@ -4672,18 +4672,18 @@ Almost all of the inner block drawing style can be customized, without affecting
     blocks/filter grid/thickness=0.25] ++(2,0)
   to[short,-o] ++(0.3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The key \IndexKey{blocks/gridnode/gridlines} controls the number of lines in the \texttt{gridnode} block, defined as parallel lines in one diagonal. This can be customised using the key, which accepts any positive integer (default is \texttt{7}).\footnote{Contributed by \href{https://github.com/circuitikz/circuitikz/pull/906}{Jakob Leide on GitHub}}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
   \node[gridnode] at (0,0) {};
   \node[gridnode,gridlines=3] at (2,0) {};
   \ctikzset{blocks/gridnode/gridlines=10}
   \node[gridnode] at (4,0) {};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Plot-type filter blocks customization.}\label{sec:block-filter-grid-cust}
 In the ``plot''-type filter blocks, you can change the appearance of the grid using the following parameters (with \verb!\ctikzset!, under the family \IndexKey{blocks/filter grid/})
@@ -4708,7 +4708,7 @@ Finally, the plots are by default rounded\footnote{This, and the hint for the ne
 
 Setting the key \IndexKey{ideal filter numbers} a small \texttt{0} and \texttt{1} are added at the left side of the grid. The two numbers can be customized using the keys \IndexKey{ideal filter number low} and \IndexKey{ideal filter number low} (by default set to \texttt{0} and \texttt{1} respectively), but notice that there is very little space there.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[lowpassp=\qty{1}{\kHz},
         blocks/filter grid/color=red,
@@ -4726,7 +4726,7 @@ Setting the key \IndexKey{ideal filter numbers} a small \texttt{0} and \texttt{1
     \draw (0,-4) to[lowpassp, ideal filter] ++(2,0)
         to[bandpassp, ideal filter] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Transistors}
 \label{sec:transistors}
@@ -4805,7 +4805,7 @@ Since version \texttt{1.6.0}, you can add the \IndexKey{doublegate} option to th
 You can use the double-gated transistor for example like this:%
 \footnote{Found at \href{https://www.electronics-notes.com/articles/electronic_components/fet-field-effect-transistor/dual-gate-mosfet.php}{this page on electronics notes}.}
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily]
 \begin{circuitikz}[european, scale=0.7, transform shape,
     circuitikz/resistors/scale=0.7]
     \draw (0,0) to[C, o-*] ++(1,0) coordinate(in)
@@ -4821,7 +4821,7 @@ You can use the double-gated transistor for example like this:%
     (Sd) to[C, -*] (Sd |- GND);
     \draw (0,0|-GND) -- (out|-GND) (0,0|-vdd) -- (out|-vdd);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since version \texttt{v1.8.1} the \texttt{fdsoi} flag has been added to draw back gates for \href{https://anysilicon.com/fdsoi/}{FDSOI} types transistors.\footnote{Suggested via email by Raphael Nägele <raphael.naegele@int.uni-stuttgart.de>; see also \href{https://github.com/circuitikz/circuitikz/issues/871}{this issue on GitHub}.}
 The flag acts on all the FET transistors.
@@ -4872,7 +4872,7 @@ In versions before \texttt{0.9.7}, transistors text (the node text) was position
 
 Notice the use of the utility functions \verb|\ctikzflip{|\texttt{\textsl{x,y,xy}}\verb|}| as explained in section~\ref{sec:mirroring-and-flipping}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
     \draw (0,0) node [npn]{T1}
     ++(1.2,0) node [npn, xscale=-1]{\ctikzflipx{T1}}
@@ -4884,11 +4884,11 @@ Notice the use of the utility functions \verb|\ctikzflip{|\texttt{\textsl{x,y,xy
     ++(2,0) node [npn, yscale=-1]{\ctikzflipy{T1}}
     ++(1.2,0) node [npn, scale=-1]{\ctikzflipxy{T1}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 There is a situation where using the legacy position makes sense: if you have a transistor with a bulk pin, and you need to connect that pin to something outside the component:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
     \draw (0,0) node [nigfetebulk](T1){T1} (T1.S) node[ground]{}
         (T1.bulk) -- ++(0.5, 0) node[vee]{};
@@ -4896,11 +4896,11 @@ There is a situation where using the legacy position makes sense: if you have a 
         (T2.S) node[ground]{}
         (T2.bulk) -- ++(0.5, 0) node[vee]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use the \texttt{legacy transistors text} to position the label ``up'', near the drain (or source, whichever is up) of the transistor --- but then we have a problem, if you use, for example, a transistor circle (it works by chance with the standard sizes, but if you change the size of the circle, you'll have problems:)
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8, transform shape]
     \ctikzset{legacy transistors text, tr circle}
     \draw (0,0) node [nigfetebulk](T1){T1} (T1.S) node[ground]{}
@@ -4912,13 +4912,13 @@ You can use the \texttt{legacy transistors text} to position the label ``up'', n
     (T2.S) node[ground]{}
     (T2.bulk) -- ++(0.8, 0) node[vee]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Since version \texttt{1.8.2} you can solve this with \IndexKey[component text: up/down]{component text=up} (or \texttt{down}, default \texttt{center}).
 This flag will move the text label of the transistors near the upper (or lower, respectively) terminal, a bit offset to the right.
 The value of this flag is taken into account only for transistors (at least, for now).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{component text=up, tr circle}
     \draw (0,0) node [nigfetebulk](T1){T1}
@@ -4933,16 +4933,16 @@ The value of this flag is taken into account only for transistors (at least, for
     (T2.S) node[ground]{}
     (T2.bulk) -- ++(1.2, 0) node[vee]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[bjtnpn, emitters=2,
     component text=up](B){pB} ++(2,0)
     node[bjtnpn](C){pC} (B.nobase) -- (C.base)
     ++(2,1); %adjust bounding box
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Transistors customization}\label{sec:styling-transistors}
 
@@ -4953,7 +4953,7 @@ The size of the arrows (if any) is controlled by the same parameters as \IndexKe
 \paragraph{Arrows.} The default position of the arrows in transistors is somewhat in the middle of the terminal; if you prefer you can move them to the end with the style key \IndexKey[transistor/arrow pos]{transistors/arrow pos=end} (the default value is \texttt{legacy}).
 \label{par:arrows}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \ctikzset{tripoles/mos style=arrows}
    \ctikzset{transistors/arrow pos=end}
@@ -4962,7 +4962,7 @@ The size of the arrows (if any) is controlled by the same parameters as \IndexKe
    \draw (0,-2) node[nmos, ](npn){};
    \draw (2,-2) node[pmos, ](npn){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If the option \IndexKey{arrowmos} is used (or after the \IndexKey[tripoles/mos style/arrows]{}command \verb!\ctikzset{tripoles/mos style/arrows}! is given), this is the output:
 \begin{groupdesc}
@@ -4986,7 +4986,7 @@ To draw the PMOS circle non-solid, use the option \IndexKey{emptycircle} or the 
 
 This example show the combined effects of the arrows and gate-circle options:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     info/.style={left=1cm, blue, text width=5em, align=right},]
     \draw (0,1) node{pmos} (2,1) node{nmos};
@@ -5001,25 +5001,25 @@ This example show the combined effects of the arrows and gate-circle options:
     \draw (0,-8) node[info, red]{no circle, no arrows, DON'T do it}
           node[pmos]{} (2,-8) node[nmos]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can also change\footnote{Thanks to the idea by \href{https://github.com/circuitikz/circuitikz/issues/655}{Dr. Matthias Jung on GitHub}.} the type of the arrow for the ``light rays'' of the phototransistors with the generic arrows options shown in~\ref{sec:tunablearrows}, using the name \texttt{opto}, like in the following (overdone) example. Also the \texttt{opto arrows} styling options (see section~\ref{sec:opto-arrows}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \draw (0,2) node[npn, photo]{} ++(2,0) node[pnp, photo]{};
     \ctikzset{opto end arrow={Triangle[angle'=60]}}
     \ctikzset{opto arrows/.cd, color=red, dash={{1pt}{1pt}}}
     \draw (0,0) node[npn, photo]{} ++(2,0) node[pnp, photo]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Circles.} Since \texttt{1.2.6}, you can add a circle\footnote{Suggested by Dr. Matthias Jung \href{https://github.com/circuitikz/circuitikz/issues/442}{on GitHub}} to most of the transistor shapes --- with the exception of multi-terminal (\texttt{bjtnpn} and \texttt{bjtpnp}, where it would be awkward anyway) and graphene FETs. The circle is intended in some case as the component's housing, and used to distinguish discrete components from integrated ones.
 \label{par:circles}
 
 To add the circle to a single transistor, you use the \IndexKey{tr circle} keys in the node; if you want all of your transistors with a circle, you can set the property \texttt{tr circle} with a \verb|\ctikzset| command (it will respect normal grouping, of course); in that case, you can use \texttt{tr circle=false} to locally disable them.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,2) node[npn]{} (2,2) node[npn, tr circle](Q){};
     % collector connected to housing
@@ -5028,14 +5028,14 @@ To add the circle to a single transistor, you use the \IndexKey{tr circle} keys 
     \draw (0,0) node[nigfete]{}
         (2,0) node[nigfete, tr circle=false]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can tweak the appearance of transistor's circles and even draw it partially; see ~\ref{sec:trans-circle-custom} for details.
 
 \paragraph{Body diodes and similar things.}\label{sec:bodydiodes-anchor} For all transistors (minus \texttt{bjtnpn} and \texttt{bjtpnp})  a body diode (or freewheeling or flyback diode) can automatically be drawn. Just use the global option \IndexKey{bodydiode}, or for single transistors, the \TikZ-option \texttt{bodydiode}.
 As you can see in the next example, the text for the diode is moved if a bodydiode is present (but beware, if you change a lot the relative dimension of components, it may become misplaced):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) node[npn,bodydiode](npn){1}
        ++(2,0)node[pnp,bodydiode](npn){};
@@ -5044,13 +5044,13 @@ As you can see in the next example, the text for the diode is moved if a bodydio
    \draw (0,-4) node[nfet,bodydiode](npn){3}
        ++(2,0)node[pfet,bodydiode](npn){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can tweak the appearance of transistor's bodydiodes; see ~\ref{sec:trans-bodydiode-custom}.
 
 For more complex snubs or protections, you can use the \IndexKey[bodydiode anchors]{body ...} anchors to add more or different things to the transistors in addition (or instead) of the flyback\IndexKey[flyback diode]{} diode.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \def\snubb#1#2{% add a snubber to a transistor
     \draw (#1.body C #2) to[short, *-, nodes width=0.02]
     ++(0.3,0) coordinate(tmp) to [R, resistors/scale=0.3]
@@ -5067,7 +5067,7 @@ For more complex snubs or protections, you can use the \IndexKey[bodydiode ancho
     \snubb{Q1}{in} \snubb{Q2}{in}
     \snubb{Q3}{out} \snubb{Q4}{out}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{HEMT customization.\label{sec:hemt}} Since \texttt{v1.6.1} the shape of the \texttt{hemt} transistor can be customized.\footnote{After a suggestion from \href{https://github.com/circuitikz/circuitikz/issues/691}{user \texttt{@epsilon-phi} on GitHub}.}
 \label{par:hemt-customization-sec}
@@ -5089,7 +5089,7 @@ The main ones are \texttt{\dots/split gate} (boolean, default \texttt{false}) th
 }
 \end{lstlisting}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \path (-1,-1) rectangle (3,3);% bounding box
     \node  [hemt] at (0,2) {A};
@@ -5101,14 +5101,14 @@ The main ones are \texttt{\dots/split gate} (boolean, default \texttt{false}) th
         circuitikz/tripoles/hemt/split gate=false
         ]  at (2,0) {D};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Schottky transistors.}
 \label{par:schottky-transistors}
 The Schottky transistors are generated by adding the \IndexKey{schottky base} key (there is also a \IndexKey{no schottky base} key that can be used if you use the other one as a default).
 You can change the size of the Schottky ``hook'' changing the parameter \IndexKey{tripoles/schottky base size} with \verb|\ctikzset{}| (default \texttt{\ctikzvalof{tripoles/schottky base size}}; the unit is the standard resistor length, scaled if needed.)
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \draw (0,4) node[npn]{}
             ++(2,0) node[npn, schottky base]{};
@@ -5119,14 +5119,14 @@ You can change the size of the Schottky ``hook'' changing the parameter \IndexKe
         \draw (0,0) node[pnp]{}
             ++(2,0) node[npn, no schottky base]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Ferroelectric transistors} You can add the \IndexKey{ferroel} ferroelectric modifier\footnote{suggested by \href{https://github.com/circuitikz/circuitikz/issues/515}{Mayeul Cantan}} to the \texttt{*mos} and \texttt{*fet} transistor  types. Similarly to the Schottky bipolar transistors, you activate it by adding the \IndexKey{ferroel gate} key (there is also a \IndexKey{no ferroel base} key that can be used if you use the other one as a default).
 \label{par:ferroelectric-transistors}
 
 The mark will follow the \texttt{transistors} class thickness, but you can adjust it independently using the class parameter \IndexKey{modifier thickness} as in passive components --- this value is relative to the class' thickness.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \draw (0,2) node[nmos]{}
             ++(2,0) node[nmos, ferroel gate]{};
@@ -5136,14 +5136,14 @@ The mark will follow the \texttt{transistors} class thickness, but you can adjus
         \draw (0,0) node[pfet]{}
             ++(2,0) node[pfet, no ferroel gate]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \paragraph{IGBT outer base.}
 \label{par:igbt-outer-base}
 Normally, in bipolar IGBTs the outer base is the same size (height) of the inner one, and of the same thickness (which will depend on the class thickness value). You can change this by setting (via \verb|\ctikzset|) the keys \IndexKey{tripoles/igbt/outer base height} (default \texttt{0.4}, the same as \texttt{base height}), and \IndexKey{tripoles/igbt/outer base thickness} (default \texttt{1.0}), which will be relative to the class thickness.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
     \draw (0,0)
     -- ++(1,0) node[nigbt, anchor=B](B){} (B.nobase)
@@ -5160,11 +5160,11 @@ Normally, in bipolar IGBTs the outer base is the same size (height) of the inner
     -- ++(1,0) node[Lpigbt, anchor=B](B){} (B.nobase)
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{UJT transistors.}\label{sec:ujt} They look better if you use \texttt{transistors/arrow pos=end}, especially if you use them with \texttt{tr circle}. If you use the key \texttt{nobase} with UJTs, the horizontal part of the controlling terminal is not drawn; notice that this \emph{will} move the \texttt{E} or \texttt{emitter} anchor, but not the generic ones like \texttt{G}.
 
-\begin{LTXexample}[basicstyle=\footnotesize\ttfamily]
+\begin{ctikzExample}[basicstyle=\footnotesize\ttfamily]
 \begin{circuitikz}[scale=0.8]
     \draw (0,5) node[nujt]{} ++(2,0) node[pujt]{}
     ++(2,0) node[nujt, tr circle]{} ++(2,0)
@@ -5180,11 +5180,11 @@ Normally, in bipolar IGBTs the outer base is the same size (height) of the inner
     % "E" anchor follows the nobase option:
     \draw[red] (A.E) |- (B.E) (C.E) |- (D.E);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Base/Gate terminal.} The Base/Gate connection of all transistors can be disabled by the options \textit{nogate} or \textit{nobase}, respectively. The Base/Gate anchors are floating, but there is an additional anchor \IndexKey{nogate}/\IndexKey{nobase}, which can be used to point to the unconnected base:
 \label{par:base-gate-terminal}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (2,0) node[npn,nobase](npn){};
    \draw (npn.E) node[below]{E};
@@ -5192,7 +5192,7 @@ Normally, in bipolar IGBTs the outer base is the same size (height) of the inner
    \draw (npn.B) node[circ]{} node[left]{B};
    \draw[dashed,red,-latex] (1,0.5)--(npn.nobase);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Bulk terminals.} You can add a bulk terminal\footnote{Thanks to Burak Kelleci <kellecib@hotmail.com>.} to \texttt{nmos} and \texttt{pmos} using the key \IndexKey{bulk} in the node (and \IndexKey{nobulk} if you set the bulk terminal by default); additional anchors \texttt{bulk} and \texttt{nobulk} are added (in the next example, \texttt{tripoles/mos style/arrows} is enacted, too):
 \label{par:bulk-terminals}
@@ -5230,7 +5230,7 @@ Also, IGBTs have anchors to access the ``bulk'' equivalent connections.
 Solder dots are scaled-down\footnote{Since \texttt{v1.6.3}, suggested by \href{https://tex.stackexchange.com/q/687225/38080}{user Hartomes on TeX StackExchange}; previously, the default scale was \texttt{1.0}, which created a clash with body diodes.} version of the normal \texttt{circ} connection dot (\emph{pole}).
 This is to convey the information that the connection is \emph{internal} to the device, and not controllable from the outside. By default, they are scaled as the bodydiode connection dots (see section~\ref{sec:trans-bodydiode-custom}), but you can change them with the command\IndexKey[transistor solderdot scale]{} \texttt{\textbackslash ctikzset\{transistor solderdot scale=\emph{x}\}}, where $x$ is the scale with respect to the normal \texttt{circ} node (default: \texttt{0.7}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \draw (0,0) to[short,*-] ++(.1,0)
         node[nigfete, solderdot, anchor=G]{};
@@ -5238,23 +5238,23 @@ This is to convey the information that the connection is \emph{internal} to the 
     \draw (2,0) to[short,*-] ++(.1,0)
         node[nigfete, solderdot, anchor=G]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Simplified symbols for depletion-mode MOSFETs}.
 \label{par:simplified-symbols-for}
 The \texttt{nmosd}, \texttt{pmosd} (symplified) symbols for depletion-mode MOSFET (introduced in \texttt{1.2.4}) behave exactly like the normal (without the final \texttt{d}) ones.
 
 By default, the thick bar (indicating the pre-formed channel) is filled with the same color as the drawing:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[ ]
     \draw (0,2) to[R] ++(2,0) node[nmosd, anchor=G]{};
     \draw[color=red] (0,0) to[R] ++(2,0) node[pmosd, anchor=G]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can change this behavior by setting the key
 \IndexKey{tripoles/nmosd/depletion color} (default value \texttt{default}, which means ``use the draw color'') to the color you want; using \texttt{none} will lead to an unfilled channel (note that in this case the color does not change automatically with the path!):
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[ ]
     \ctikzset{tripoles/nmosd/depletion color=gray}
     \draw (0,2) to[R] ++(2,0) node[nmosd, anchor=G]{};
@@ -5266,25 +5266,25 @@ You can change this behavior by setting the key
     \draw[color=blue] (0,-2) to[R] ++(2,0)
         node[pmosd, anchor=G, bulk]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 Obviously you have the equivalent \IndexKey{tripoles/pmosd/depletion color} for type-P transistors.
 
 They also have path-style syntax, as the other transistors.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[ ]
     \draw (0,0) to[Tnmosd] ++(2,0)
     to[Tpmosd, invert] ++(0,-2)
     ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Gate/Base gap coloring.} You can color the space representing the gate capacitor or the insulated base by using the key \IndexKey{tr gap fill} (default \texttt{none}, which means nothing is drawn there). This fill is done \emph{after} any circle fill but before any additional modifier (see the example below). You can use it locally or set it globally (normal scoping works, as ever).
 \label{par:gate-base-gap}
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{tikzpicture}
         \node[nigfete, tr gap fill=green] at(0,0){};
         \node[nigfete, tr gap fill=red, tr circle,
@@ -5292,7 +5292,7 @@ They also have path-style syntax, as the other transistors.
         \node[nmos, tr gap fill=cyan, ferroel gate](A)
             at(3,0){};
     \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Multiple terminal transistors customization}
 \label{sec:multiple-terminal-transistors}
@@ -5315,7 +5315,7 @@ The anchors are present even if there is no circle, so you can use them to draw 
 
 The position of the circle on collector and emitter by default is the one shown above; the position along the base can be adjusted in most transistors using the \verb|\ctikzset| parameter \IndexKey{transistor circle/default base in} (by default \texttt{\ctikzvalof{transistor circle/default base in}}); \texttt{njfet} and \texttt{pjfet} use \texttt{transistor circle/njfet base in} (default \texttt{\ctikzvalof{transistor circle/njfet base in}}; the same for \texttt{pjfet}) and, finally, \texttt{isfet} uses \texttt{transistor circle/isfet base in} (default \texttt{\ctikzvalof{transistor circle/isfet base in}}). You can change the resulting size of the circle by setting to something different to \texttt{1.0} the parameter \IndexKey{transistor circle/scale circle radius} --- that will move the anchors too; for example:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=1.5, transform shape]
     \draw (0,0) node[npn, tr circle](Q1){};
     \node [circ] at (Q1.circle C){};
@@ -5323,7 +5323,7 @@ The position of the circle on collector and emitter by default is the one shown 
     \draw[color=red] (0,0) node[npn, tr circle](Q2){};
     \node [circ, color=red] at (Q2.circle C){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Line and color.} Normally the circle follows the style of the component --- the line thickness is fixed by the class element \texttt{transistors/thickness} and the color is the same as the component color. You can change, if you need, all of these things using the parameters of the following table (the parameters are under the \verb|\ctikzset| category root \IndexKey{transistor circle/}.
 \label{par:line-and-color}
@@ -5343,7 +5343,7 @@ The position of the circle on collector and emitter by default is the one shown 
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,2) node[npn, tr circle](Q1){};
     \ctikzset{transistor circle/relative thickness=2}
@@ -5354,11 +5354,11 @@ The position of the circle on collector and emitter by default is the one shown 
     \ctikzset{transistor circle/dash={{4pt}{4pt}{1pt}{4pt}}}
     \draw[color=blue] (2,0) node[npn, tr circle](Q1){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, using the class style you can do quite interesting things.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \ctikzset{transistors/thickness=4, transistors/fill=cyan!30,
         transistor circle/relative thickness=0.25,}
@@ -5366,7 +5366,7 @@ Finally, using the class style you can do quite interesting things.
     \ctikzset{transistor circle/dash={{2pt}{2pt}}}
     \draw (1.5,0) node[npn, tr circle, xscale=-1](Q2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Partially drawn circle borders}
 \label{par:partially-drawn-circle}
@@ -5388,7 +5388,7 @@ The part of the border are numbered from 1 to 4 as shown below:
 \end{quote}
 The dashed line pattern can be changed by setting the key \IndexKey{transistor circle/partial border dash} (default \verb|{{2pt}{2pt}}|). Be careful with the extra set of braces here.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \ctikzset{transistors/thickness=4, transistors/fill=cyan!30,
         transistor circle/relative thickness=0.25,
@@ -5397,9 +5397,9 @@ The dashed line pattern can be changed by setting the key \IndexKey{transistor c
     \ctikzset{transistor circle/dash={{2pt}{2pt}}}
     \draw (1.5,0) node[npn, tr circle, xscale=-1](Q2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \ctikzset{transistors/thickness=4, transistors/fill=cyan!30,
         transistor circle/relative thickness=0.25,
@@ -5410,7 +5410,7 @@ The dashed line pattern can be changed by setting the key \IndexKey{transistor c
     \draw[dashed] (Q1.circle top) -- (Q2.circle top);
     \draw[dashed] (Q1.circle bottom) -- (Q2.circle bottom);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Transistor bodydiode customization}\label{sec:trans-bodydiode-custom}
 
@@ -5433,7 +5433,7 @@ You can change the style of the bodydiode\footnote{Suggested by \href{https://te
 
 The following is a quite extensive example. Obviously, a good strategy in this case is to define styles for the options, or, better, set the option in your style file or in the preamble (for coherency).
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{tikzpicture}[red solid thin bodydiode/.style={bodydiode,
         circuitikz/transistor bodydiode/dash=none,
         circuitikz/transistor bodydiode/color=red,
@@ -5455,23 +5455,23 @@ The following is a quite extensive example. Obviously, a good strategy in this c
           circuitikz/transistor bodydiode/dot scale=1] {$Q_6$};
     \path (7,0); %% adjust bounding box (node text is outside it!)
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Transistors anchors}
 \label{sec:transistors-anchors}
 
 For \textsc{nmos}, \textsc{pmos}, \textsc{nfet}, \textsc{nigfete}, \textsc{nigfetd}, \textsc{pfet}, \textsc{pigfete}, and \textsc{pigfetd}  transistors  one has \texttt{base}, \texttt{gate}, \texttt{source} and \texttt{drain} anchors (which can be abbreviated with \texttt{B}, \texttt{G}, \texttt{S} and \texttt{D}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[nmos] (mos)  {}
   (mos.gate) node[anchor=east] {G}
   (mos.drain) node[anchor=south] {D}
   (mos.source) node[anchor=north] {S}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[pigfete] (pigfete)  {}
   (pigfete.G) node[anchor=east] {G}
@@ -5479,38 +5479,38 @@ For \textsc{nmos}, \textsc{pmos}, \textsc{nfet}, \textsc{nigfete}, \textsc{nigfe
   (pigfete.S) node[anchor=south] {S}
   (pigfete.bulk) node[anchor=west] {Bulk}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Similarly \textsc{njfet} and \textsc{pjfet} have  \texttt{gate}, \texttt{source} and \texttt{drain} anchors (which can be abbreviated with  \texttt{G}, \texttt{S} and \texttt{D}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[pjfet] (pjfet)  {}
   (pjfet.G) node[anchor=east] {G}
   (pjfet.D) node[anchor=north] {D}
   (pjfet.S) node[anchor=south] {S}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 For \textsc{npn}, \textsc{pnp}, \textsc{nigbt} and \textsc{pigbt} transistors, the anchors are  \texttt{base}, \texttt{emitter} and \texttt{collector} anchors (which can be abbreviated with \texttt{B}, \texttt{E} and \texttt{C}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[npn] (npn)  {}
   (npn.base) node[anchor=east] {B}
   (npn.collector) node[anchor=south] {C}
   (npn.emitter) node[anchor=north] {E}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[pigbt] (pigbt)  {}
   (pigbt.B) node[anchor=east] {B}
   (pigbt.C) node[anchor=north] {C}
   (pigbt.E) node[anchor=south] {E}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 Notice that the geographical anchors of transistors are \emph{not} affected by either the bodydiode and the circle options; the label text is also outside of them. This is to permit aligning the components independently from those features. On the other hand, this can sometimes create problems because that element is outside the bounding box automatically calculated by \TikZ{}.
@@ -5522,7 +5522,7 @@ The exception is the \texttt{right} anchor which, when a circle is present, indi
 
 All transistors, except the multi-terminal \texttt{bjtnpn} and \texttt{bjtpnp}, (since \texttt{0.9.6}) have internal nodes on the terminal corners, called \texttt{inner up}  and \texttt{inner down}; you do not normally need them, but they are here for special applications:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \node [npn](A) at(0,2) {};
     \node [pmos](B) at(0,0) {};
@@ -5534,7 +5534,7 @@ All transistors, except the multi-terminal \texttt{bjtnpn} and \texttt{bjtpnp}, 
             at (\e.\a) {\a};
         }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Additionally, you can access the position for the flyback diodes and possibly \IndexKey[snubbers]{}snubbers as shown in~\ref{sec:bodydiodes-anchor}.
 
@@ -5560,7 +5560,7 @@ The additional anchors \IndexKey{vcenter} (vertical geometric center of the coll
 
 A complete example of multiple terminal transistor application is the following PNP double current mirror circuit.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{transistors/arrow pos=end}
     \draw (0,0) node[bjtpnp, xscale=-1](Q1){%
@@ -5579,12 +5579,12 @@ A complete example of multiple terminal transistor application is the following 
         anchor=west]{\rotatebox{90}{$I_0$}};
     \path (b) ++(0.5,0); % bounding box adjust
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 Here is one composite example (please notice that the \texttt{xscale=-1} style would also reflect the label of the transistors, so here a new node is added and its text is used, instead of that of \texttt{pnp1}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
   \begin{circuitikz} []\draw
   (0,0) node[pnp] (pnp2) {Q2}
   (pnp2.B) node[pnp, xscale=-1, anchor=B] (pnp1) {}
@@ -5595,12 +5595,12 @@ Here is one composite example (please notice that the \texttt{xscale=-1} style w
   (pnp1.E) -- (pnp2.E)  (npn1.E) -- (npn2.E)
   (pnp1.B) node[circ] {} |- (pnp2.C) node[circ] {}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the text labels of transistors are outside the bounding box of the component (that is, the set of geographical anchors). If it is a problem, use a separate text node to set the transistor's label.
 Of course, transistors like other components can be reflected vertically:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[pigfete, yscale=-1] (pigfete)  {}
   (pigfete.bulk) node[anchor=west] {Bulk}
@@ -5608,10 +5608,10 @@ Of course, transistors like other components can be reflected vertically:
   (pigfete.D) node[anchor=south] {D}
   (pigfete.S) node[anchor=north] {S}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, double-gated components (MOSes, FETs, IGBTs) have an extra anchor \IndexKey{centergap} positioned in the middle of the ``gate capacitor'' or base.
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \node [nmos](A) at (0,3) {};
         \node [nfet](B) at (0,1.5) {};
@@ -5621,7 +5621,7 @@ Finally, double-gated components (MOSes, FETs, IGBTs) have an extra anchor \Inde
                 node[ocirc]{} -- ++(1,0)
                 node[right, font=\tiny]{centergap};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 For UJT transistors anchors, see section~\ref{sec:ujt}.
 
@@ -5630,16 +5630,16 @@ For UJT transistors anchors, see section~\ref{sec:ujt}.
 
 For syntactical convenience standard transistors (not multi-terminal ones) can be placed using the normal path notation used for bipoles. The transistor type can be specified by  simply adding a ``T'' (for transistor) in front of the node name of the transistor. It will be placed with the base/gate orthogonal to the direction of the path:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[njfet] {1}
   (-1,2) to[Tnjfet=2] (1,2)
     to[Tnjfet=3, mirror] (3,2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Access to the gate and/or base nodes can be gained by naming the transistors with the \texttt{n} or \IndexKey{name} path style:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw[yscale=1.1, xscale=.8]
   (2,4.5) -- (0,4.5) to[Tpmos=p1, n=p1] (0,3)
      to[Tnmos=n1, n=n1] (0,1.5)
@@ -5650,7 +5650,7 @@ Access to the gate and/or base nodes can be gained by naming the transistors wit
   (n2.G) to[short, -o] ($(n2.G)+(3,0)$)
   (0,3) to[short, -o] (-1,3)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Transistors used in path are fully path-style components, so to flip and rotate them you should use  \texttt{mirror} and \texttt{invert} as shown in section~\ref{sec:mirror-flip-path}.
 
@@ -5731,7 +5731,7 @@ fully configurable, and the attributes are described below\IndexKey[tubes custom
 Conventionally, the model of the tube is indicated at the \verb|east| anchor, and you can access filament anchors if you need them:
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \ctikzset{tubes/width=1.4, tubes/height=1}
 \begin{circuitikz}
     \draw (0,2) node[triode, filament] (Tri) {};
@@ -5745,7 +5745,7 @@ Conventionally, the model of the tube is indicated at the \verb|east| anchor, an
     \path (Tri.filament center) node[blue,ocirc]{};
     \draw (Pent.filament center) -- ++(0,-1) node[tlground]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -5844,7 +5844,7 @@ The part of the border are numbered from 1 to 6 as shown below:
 
 The dashed line pattern can be changed by setting the key \texttt{tubes/partial border dash} (default \verb|{{2pt}{2pt}}|).\footnote{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.} Be careful with the extra set of braces here.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[circuitikz/tubes/fill=cyan!20,
         circuitikz/tubes/partial borders=012012]
         \draw (0,0) node[pentode]{};
@@ -5856,7 +5856,7 @@ The dashed line pattern can be changed by setting the key \texttt{tubes/partial 
         circuitikz/tubes/partial border dash=%
             {{3pt}{1pt}{1pt}{1pt}}]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Multi-anode tube}
@@ -5886,7 +5886,7 @@ The additional parameters/flags available only for \IndexKey[matube (multi-anode
 
 In the next example, we define a 10-anodes VFD tube:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{vfd 10/.style={matube, filament, nocathode,
         circuitikz/tubes/.cd,
         width=3.6, height=1, anodes=10, anode width=0.6,
@@ -5897,12 +5897,12 @@ In the next example, we define a 10-anodes VFD tube:
    \foreach \i in {1,...,10} \path (A.anode \i)
         node[red, ocirc]{} node[above]{\tiny \i};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 And a 10-cathodes nixie tube:
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{nixie/.style={matube, nogrid, nixieanode,
         anodedot, circuitikz/tubes/.cd, cathode width=0.6,
         width=3.6, height=1, anodes=10, anode width=0.6,
@@ -5913,7 +5913,7 @@ And a 10-cathodes nixie tube:
     node[red, ocirc]{} node[above]{\tiny \i};
     \path (A.nixie a) node[red, ocirc]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Other tubes-like components}
 \label{sec:other-tubes-like}
@@ -5927,7 +5927,7 @@ The \texttt{magnetron} and \texttt{dynode} shapes will also scale with \texttt{t
     \footnotetext{Suggested by the user \texttt{ferdymercury} on \href{https://github.com/circuitikz/circuitikz/issues/469}{GitHub}.}
 \end{groupdesc}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,-2)node[rground](gnd){} to[voltage source,v<={HV}]++(0,3)--++(1,0)to[V,n=DC]++(2,0);
 \draw (2,-1) node[magnetron,scale=1](magn){};
@@ -5938,7 +5938,7 @@ The \texttt{magnetron} and \texttt{dynode} shapes will also scale with \texttt{t
 \draw (magn.cathode2)node[above]{$2$};
 \draw[->](magn.east) --++(1,0)node[right]{$RF_{out}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \paragraph{Dynode customization.}
@@ -5960,18 +5960,18 @@ The dynode element can be heavily customized. The parameters are the following (
 \end{center}
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american] \ctikzset{tubes/thickness=4}
     \draw (0,0) to[R] (2,0) node[dynode]{} to[R,-*] (4,0);
     \ctikzset{monopoles/dynode/.cd,
         arc angle=0, arc pos=0.7, top width=0.5}
     \draw (4,0) node[dynode]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use styles and the parameters to create different types of electrodes:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american] \ctikzset{tubes/thickness=4}
     \tikzset{anode/.style={dynode,
             circuitikz/monopoles/dynode/arc angle=90},
@@ -5982,7 +5982,7 @@ You can use styles and the parameters to create different types of electrodes:
     \draw (0,0) node[dynode]{} (1,0) node[anode]{}
            (2,0) node[photocatode]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{RF components}\label{sec:RF}
@@ -6016,7 +6016,7 @@ Notes that in the transmission and receiving antennas, the ``waves'' are outside
 \end{groupdesc}
 
 The \texttt{waves} and \texttt{harmonics} can help with RF block diagrams
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 % Author: Prof. Dr. Matthias Jung, DL9MJ % Year: 2023
 \begin{circuitikz}[european]
     \draw(0,0) node [dinantenna](ant1){};
@@ -6034,7 +6034,7 @@ The \texttt{waves} and \texttt{harmonics} can help with RF block diagrams
         node[below](foo){$f=$\,\qtyrange{582}{590}{\mega\hertz}};
     \draw(foo.south) node[below](){DVB-T2 Kanal 35};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{RF elements customization}
 \label{sec:rf-elements-customization}
@@ -6049,7 +6049,7 @@ Finally, you can change the size of the smaller circle (the connecting part) of 
 
 For the length parameter of the transmission line there is a shortcut in the form of the direct parameter \IndexKey{mstlinelen}.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
     \draw (0,0) node[msport, right, xscale=-1]{}
     to[mstline, -o]  ++(3,0) coordinate(there)
@@ -6060,11 +6060,11 @@ For the length parameter of the transmission line there is a shortcut in the for
         \draw (here) -- ++(0, -0.5) node[msrstub, yscale=-1,
             circuitikz/monopoles/msrstub/radius=0]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The legacy \texttt{tline} can be used as in the following example. You can change the length with the key  \IndexKey{bipoles/tline/width} (default \texttt{0.6}). The ``bare'' version, which differs only for the small line on the visible ellipse, and activated with the boolean key \texttt{\dots/bare}, is useful as a substitute for \texttt{tlinestub} (with more flexibility).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \tikzset{bare tl/.style={tlineshape,
     circuitikz/bipoles/tline/bare=true}}
@@ -6072,7 +6072,7 @@ The legacy \texttt{tline} can be used as in the following example. You can chang
         to[TL, bipoles/tline/width=1] ++(3,0)
         node[bare tl, anchor=left]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Electro-Mechanical Devices}
 \label{sec:electro-mechanical-devices}
@@ -6106,29 +6106,29 @@ Apart from the standard geographical anchors, \texttt{elmech} has the border anc
 \end{quote}
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (2,0) node[elmech](motor){M};
 \draw (motor.north) |-(0,2) to [R] ++(0,-2) to[dcvsource]++(0,-2) -| (motor.bottom);
 \draw[thick,->>](motor.right)--++(1,0)node[midway,above]{$\omega$};
 \end{circuitikz}
-\end{LTXexample}
-\begin{LTXexample}
+\end{ctikzExample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (2,0) node[elmech](motor){};
 \draw (motor.north) |-(0,2) to [R] ++(0,-2) to[dcvsource]++(0,-2) -| (motor.bottom);
 \draw[thick,->>](motor.center)--++(1.5,0)node[midway,above]{$\omega$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The symbols can also be used along a path, using the transistor-path-syntax(\texttt{T} in front of the shape name, see section \ref{sec:transasbip}). Don't forget to use parameter $n$ to name the node and get access to the anchors:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) to [Telmech=M,n=motor] ++(0,-3) to [Telmech=M] ++(3,0) to [Telmech=G,n=generator] ++(0,3) to [R] (0,0);
 \draw[thick,->>](motor.left)--(generator.left)node[midway,above]{$\omega$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -6208,7 +6208,7 @@ The set of anchors, to which you should add the standard ``geographical'' \textt
 Also, the standard ``geographical'' \texttt{north}, \texttt{north east}, etc. are defined.
 A couple of examples follow:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[transformer] (T) {}
   (T.A1) node[anchor=east] {A1}
@@ -6219,9 +6219,9 @@ A couple of examples follow:
   (T.inner dot A1) node[circ]{}
   (T.inner dot B2) node[circ]{}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[gyrator] (G) {}
   (G.A1) node[anchor=east] {A1}
@@ -6230,7 +6230,7 @@ A couple of examples follow:
   (G.B2) node[anchor=west] {B2}
   (G.base) node{K}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Moreover, you can access the two internal coils (inductances); if your transformer node is called \texttt{T}, they are named \texttt{T-L1} and \texttt{T-L2}. Notice that the two inductors are rotated (by -90 degrees the first, +90 degrees the second) so you have to be careful with the anchors. Also, the \texttt{midtap} anchor of the inductors can be on the external or internal side depending on the numbers of coils. Finally, the anchors \texttt{L1.a} and \texttt{L1.b} are marking the start and end of the coils.
 
@@ -6256,7 +6256,7 @@ Moreover, you can access the two internal coils (inductances); if your transform
 \end{circuitikz}
 \end{quote}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[ground](GND){} to [sV] ++(0,2) -- ++(1,0)
     node[transformer, circuitikz/inductors/coils=6,
@@ -6265,7 +6265,7 @@ Moreover, you can access the two internal coils (inductances); if your transform
 \draw (T-L2.midtap) to[short, *-o] (T.B1 |- T-L2.midtap);
 \node [ocirc] at (T.B1){}; \node [ocirc] at (T.B2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 \subsubsection{Transformers customization}
 \label{sec:transformers-customization}
 
@@ -6273,7 +6273,7 @@ Transformers are in the \texttt{inductors} class (also the gyrator\dots), so the
 
 You can change the aspect of a quadpole using the corresponding parameters \IndexKey{quadpoles/*/width} and  \IndexKey{quadpoles/*/heigth} (substitute the star for \texttt{transformer}, \texttt{transformer core} or \texttt{gyrator}; default value is \texttt{1.5} for all). You have to be careful to not choose value that overlaps the components!
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{quadpoles/transformer/width=1,
     quadpoles/transformer/height=2}
@@ -6282,7 +6282,7 @@ You can change the aspect of a quadpole using the corresponding parameters \Inde
     (T.inner dot A1) node[circ]{}
     (T.inner dot B2) node[circ]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Transformers also inherit the \texttt{inductors/scale} (see~\ref{sec:tweak-l}) and similar parameters. It's your responsibility to set the aforementioned parameters if you change the scale or width of inductors.
 
@@ -6303,18 +6303,18 @@ You can change the style of the core lines\footnote{Suggested by \href{https://g
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) node[transformer core](A){};
     \ctikzset{transformer core/.cd, relative thickness=2, color=red, dash={{4pt}{2pt}}}
     \draw (2,0) node[transformer core](B){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Another very useful parameter is \IndexKey{quadpoles/*/inner} (default \texttt{0.4}) that determine which part of the component is the ``vertical'' one. So, setting that parameter to 1 will eliminate the horizontal part of the component (obviously, to maintain the general aspect ratio you need to change the width also):
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[transformer] (T) {}
   (T.A1) node[anchor=east] {A1}
@@ -6328,11 +6328,11 @@ Another very useful parameter is \IndexKey{quadpoles/*/inner} (default \texttt{0
   (P.inner dot A2) node[ocirc]{}
   (P.inner dot B2) node[ocirc]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This can be useful if you want to put seamlessly something in series with either side of the component; for simplicity, you have a style setting \IndexKey{quadpoles style} to toggle between the standard shape of double bipoles  (called \IndexKey[quadpoles style inward]{inward}, default) and the one without horizontal leads (called \IndexKey[quadpoles style inline]{inline}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{inductor=cute, quadpoles style=inline}
 \draw
@@ -6344,7 +6344,7 @@ This can be useful if you want to put seamlessly something in series with either
   (T.B1) node[above, ocirc]{}
   (T.B2) -- (GND);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Styling transformer's coils independently}
@@ -6354,7 +6354,7 @@ Since \texttt{0.9.6}, you can tweak the style of each of the coils of the transf
 changing the value of the two styles \IndexKey{transformer L1} and \IndexKey{transformer L2};
 the default for both are \texttt{\{\}}, that means inherit the inductors style in force.
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \begin{circuitikz}[american]
     \begin{scope}
         \ctikzset{transformer L1/.style={inductors/coils=1, inductors/width=0.2}}
@@ -6374,11 +6374,11 @@ the default for both are \texttt{\{\}}, that means inherit the inductors style i
         }
     }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \textbf{Caveat:} the size of the transformer is independent from the styles for \texttt{L1} and \texttt{L2}, so they follow whatever the parameters for the inductances were before applying  them. In other words, the size of the transformer  could result too small if you are not careful.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{transformer L1/.style={inductors/width=1.8, inductors/coils=13}}
     % too small!
@@ -6387,11 +6387,11 @@ the default for both are \texttt{\{\}}, that means inherit the inductors style i
     \ctikzset{quadpoles/transformer core/height=2.4}
     \draw (2.5,0) node[transformer core](T1){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can obviously define a style for a ``non-standard'' transformer. For example, you can have a current transformer\footnote{Suggested by Alex Pacini on \href{https://github.com/circuitikz/circuitikz/issues/297}{GitHub}} defined like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     TA core/.style={transformer core,
         % at tikz level, you have to use circuitikz/ explicitly
@@ -6404,7 +6404,7 @@ You can obviously define a style for a ``non-standard'' transformer. For example
     % changes are local
     \draw (0,-3) node[transformer]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Remember that the default \texttt{pgfkeys} directory is \texttt{/tikz} for nodes and for the options of the environment, so you \emph{have} to use the full path (with \texttt{circuitikz/}) there.
 
@@ -6458,7 +6458,7 @@ Generic double bipoles are meant to be used through a style, choosing the left a
     \item \IndexKey{every double bipole L}, \IndexKey{every double bipole R}: a style that is enacted when drawing the component; by default it's void.
 \end{itemize}
 For example, the LED-diode double bipole at the start of the section could be obtained this way:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     led to D/.style={double bipole,
         % at tikz level, you have to use circuitikz/ explicitly
@@ -6471,10 +6471,10 @@ For example, the LED-diode double bipole at the start of the section could be ob
     ]
     \draw (0,0) node[led to D]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As a final example, and given that the addition of generic double bipole was stimulated by an issue opened by \href{https://github.com/circuitikz/circuitikz/issues/641}{user erwindenboer on GitHub} suggesting the addition of a \IndexKey[nullor]{nullor} shape, the nullor can be obtained like this:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     nullor/.style={double bipole,
         % at tikz level, you have to use circuitikz/ explicitly
@@ -6485,7 +6485,7 @@ As a final example, and given that the addition of generic double bipole was sti
     ]
     \draw (0,0) node[nullor](T1){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 although now adding currents and voltages is not as trivial as if the component is built with a subcircuit\dots
 
 
@@ -6512,7 +6512,7 @@ although now adding currents and voltages is not as trivial as if the component 
 
 The op amp defines the inverting input (\texttt{-}), the non-inverting input (\texttt{+}) and the output (\texttt{out}) anchors:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[op amp] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6521,10 +6521,10 @@ The op amp defines the inverting input (\texttt{-}), the non-inverting input (\t
   (opamp.up) --++(0,0.5) node[vcc]{5\,\textnormal{V}}
   (opamp.down) --++(0,-0.5) node[vee]{-5\,\textnormal{V}}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 There are also two more anchors defined, \texttt{up} and \texttt{down}, for the power supplies:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[op amp] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6534,10 +6534,10 @@ There are also two more anchors defined, \texttt{up} and \texttt{down}, for the 
   (opamp.up) ++ (0,.5) node[above] {\SI{12}{\volt}}
      -- (opamp.up)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The fully differential op amp defines two outputs:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[fd op amp] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6546,10 +6546,10 @@ The fully differential op amp defines two outputs:
   (opamp.out -) node[right] {out -}
   (opamp.down) node[ground] {}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The instrumentation amplifier inst amp defines also references (normally you use the \texttt{down}, unless you are flipping the component):
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[inst amp] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6560,10 +6560,10 @@ The instrumentation amplifier inst amp defines also references (normally you use
   (opamp.refv down) node[ground]{}
   (opamp.refv up) to[short, -o] ++(0,0.3)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The fully differential instrumentation amplifier inst amp defines two outputs:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[fd inst amp] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6575,10 +6575,10 @@ The fully differential instrumentation amplifier inst amp defines two outputs:
   (opamp.refv down) node[ground]{}
   (opamp.refv up) to[short, -o] ++(0,0.3)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The instrumentation amplifier with resistance terminals (\texttt{inst amp ra}) also defines terminals to add an amplification resistor:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[inst amp ra] (opamp) {}
   (opamp.+) node[left] {$v_+$}
@@ -6590,11 +6590,11 @@ The instrumentation amplifier with resistance terminals (\texttt{inst amp ra}) a
   (opamp.refv up) to[short, -o] ++(0,0.3)
   (opamp.ra-) to[R] (opamp.ra+)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Amplifiers also have ``border''\IndexKey[amplifier border anchors]{} anchors (just add \texttt{b}, without space, to the anchor, like \texttt{b+} or \texttt{bin up} and so on). These can be useful to add ``internal components''  or to modify the component. Also the \IndexKey{leftedge} anchor (on the border midway between input) is available.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,2.2) node[op amp](OA){IA1};
     \node[oosourceshape, rotate=90, scale=0.5]
@@ -6605,7 +6605,7 @@ Amplifiers also have ``border''\IndexKey[amplifier border anchors]{} anchors (ju
         to[R, resistors/scale=0.5]
         (tmp|-A.bin down) -- (A.bin down);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Amplifiers customization}\label{sec:amplifiers-customization}
 
@@ -6615,7 +6615,7 @@ You can scale the amplifiers using the key \IndexKey{amplifiers/scale} and setti
 \label{par:input-polarity}
 All these amplifiers have the possibility to flip input and output (if needed) polarity. You can change polarity of the input with the
 \IndexKey{noinv input down} (default) or \IndexKey{noinv input up} key; and the output with \IndexKey{noinv output up} (default) or \IndexKey{noinv output down} key:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[fd inst amp,
      noinv input up,
@@ -6629,7 +6629,7 @@ All these amplifiers have the possibility to flip input and output (if needed) p
   (opamp.refv down) node[ground]{}
   (opamp.refv up) to[short, -o] ++(0,0.3)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 When you use the \texttt{noinv input/output ...} keys the anchors (\texttt{+}, \texttt{-}, \texttt{out +}, \texttt{out -}) will change with the effective position of the terminals. You also have the anchors \IndexKey{in up}, \IndexKey{in down}, \IndexKey{out up}, \IndexKey{out down} that will not change with the positive or negative sign.
 
@@ -6644,7 +6644,7 @@ The font used is set in several keys, but you can change it globally with \Index
 \end{lstlisting}
 to have plus and minus symbols that are bigger and blue.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     % change in this circuit only
     \tikzset{amp symbol font={\color{blue}\small\boldmath}}
@@ -6656,12 +6656,12 @@ to have plus and minus symbols that are bigger and blue.
     \ctikzset{amplifiers/minus={$\ominus$}}
     \draw (0,-2.2) node[fd op amp]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can remove the symbols by setting them to the null symbol \texttt{\{\}}.
 If you want different symbols for input and output you can use a null symbol and put them manually using the border anchors.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     % unset ampflier symbols
     \ctikzset{amplifiers/plus={}}
@@ -6677,7 +6677,7 @@ If you want different symbols for input and output you can use a null symbol and
     \node [font=\small\bfseries, below] at(A.bout up) {3};
     \node [font=\small\bfseries, above] at(A.bout down) {4};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Input and output pins length.}
 \label{par:input-and-output-pin-lengths}
@@ -6687,7 +6687,7 @@ Making the latter equal to one will set the length of the pin to zero\IndexKey[a
 
 For example, for the normal operational amplifier the key \IndexKey{tripoles/op amp/width} defaults to 1.7 and \IndexKey{tripoles/op amp/port width} is 0.7 (you need to peek that values in the source file \IndexKey{pgfcirctripoles.tex}). So you can do this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
   \draw (0,0) node[op amp](A){};
   \ctikzset{tripoles/op amp/port width=1,
@@ -6698,13 +6698,13 @@ For example, for the normal operational amplifier the key \IndexKey{tripoles/op 
     (A.out) node[red, circ]{} (A.+) node[blue, circ]{}
     (B.out) node[red, circ]{} (B.+) node[blue, circ]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Main amplifier label.} The amplifier label (given as the text  of the node) is normally more or less centered in the shape (in the case of the triangular shape, it is shifted a bit to the left to \emph{seem} visually centered); since version \texttt{1.1.0} you can move it at the left side plus a fixed offset setting the key \IndexKey{component text} or the style with the same name to \texttt{left}; by default the key is \texttt{center}.
 \label{par:main-amplifier-label}
 You can change the offset with the key \IndexKey{left text distance} (default \texttt{0.3em}; you must use a length here). These parameters are shared with IEEE-style logic ports.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,2.5) node[plain amp]{\texttt{741}};
     \draw (3,2.5)
@@ -6715,7 +6715,7 @@ You can change the offset with the key \IndexKey{left text distance} (default \t
     \ctikzset{left text distance=0.6em}
     \draw (3,0) node[op amp]{\texttt{741}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 These keys are also used for the positioning of the labels in the label positioning of IEEE logic gates (see~\ref{sec:ieeestdports}).
 
@@ -6727,7 +6727,7 @@ Since 0.9.0, the default appearance of the symbol has changed to be more in line
 
 You can change the distances of the inputs, using \IndexKey{tripoles/en amp/input height} (default 0.3):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{tripoles/en amp/input height=0.45}
     \draw (0,0)node[en amp](E){}
@@ -6735,11 +6735,11 @@ You can change the distances of the inputs, using \IndexKey{tripoles/en amp/inpu
         (E.-) node[left] {$v_{\mathrm{in}-}$}
         (E.+) node[left] {$v_{\mathrm{in}+}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 and of course the key \IndexKey{noinv input up} is fully functional:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{tripoles/en amp/input height=0.45}
     \draw (0,0)node[en amp, noinv input up](E){}
@@ -6747,11 +6747,11 @@ and of course the key \IndexKey{noinv input up} is fully functional:
         (E.-) node[left] {$v_{\mathrm{in}-}$}
         (E.+) node[left] {$v_{\mathrm{in}+}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 To flip the amplifier in the horizontal direction, you can use \texttt{xscale=-1} as usual:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{tripoles/en amp/input height=0.45}
     \draw (0,0)node[en amp, xscale=-1, noinv input up](E){}
@@ -6759,24 +6759,24 @@ To flip the amplifier in the horizontal direction, you can use \texttt{xscale=-1
         (E.-) node[right] {$v_{\mathrm{in}-}$}
         (E.+) node[right] {$v_{\mathrm{in}+}$};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the label is fully mirrored, so check below for the generic way to change this.
 
 You can use the new key \IndexKey{en amp text A} to change the infinity symbol with an A:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0)node[en amp, en amp text A](E){}
         (E.out) node[right] {$v_{\mathrm{out}}$}
         (E.-) node[left] {$v_{\mathrm{in}-}$}
         (E.+) node[left] {$v_{\mathrm{in}+}$} ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 And if you want, you can completely change the text using the key \IndexKey{en amp text={}}, which by default is \verb|$\mathstrut{\triangleright}\,{\infty}$|:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0)node[en amp, en amp text={%
             ${\triangleright}$ \small 200}](E){}
@@ -6784,7 +6784,7 @@ And if you want, you can completely change the text using the key \IndexKey{en a
         (E.-) node[left] {$v_{\mathrm{in}-}$}
         (E.+) node[left] {$v_{\mathrm{in}+}$} ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice two things here: the first, that \verb|\triangleright| is enclosed in braces to remove the default spacing it has as a binary operator, and that \texttt{en amp text A} is simply a shortcut for
 
@@ -6795,18 +6795,18 @@ Notice two things here: the first, that \verb|\triangleright| is enclosed in bra
 
 To combine flipping with a generic label you just do:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0)node[en amp, xscale=-1, en amp text A](E){}
         (E.out) node[left] {$v_{\mathrm{out}}$}
         (E.-) node[right] {$v_{\mathrm{in}-}$}
         (E.+) node[right] {$v_{\mathrm{in}+}$} ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 But notice that the ``A'' is also flipped by the \texttt{xscale} parameter. So the solution in this case is to use \texttt{scalebox}, like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0)node[en amp, xscale=-1, en amp text={%
     ${\triangleright}$ \scalebox{-1}[1]{\small 200}}](E){}
@@ -6814,7 +6814,7 @@ But notice that the ``A'' is also flipped by the \texttt{xscale} parameter. So t
         (E.-) node[right] {$v_{\mathrm{in}-}$}
         (E.+) node[right] {$v_{\mathrm{in}+}$} ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Designing your own amplifier}\label{sec:muxdemux-amplis}
@@ -6824,7 +6824,7 @@ If you need a different kind of amplifier\IndexKey[amplifier, generic shapes]{},
 (you need version \texttt{1.0.0} for this to work,
 and \texttt{1.3.8} for the \texttt{draw only...} option).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{tdax/.style={muxdemux,
         muxdemux def={NL=2, Lh=3, NR=1, Rh=0,
         NB=4, NT=5}, font=\scriptsize\ttfamily}}
@@ -6833,7 +6833,7 @@ and \texttt{1.3.8} for the \texttt{draw only...} option).
     \draw (2.5,0) node[tdax, muxdemux def={Rh=0.5},
     draw only top pins={1,4-5}]{TDA2};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Switches, buttons and jumpers}
@@ -6872,22 +6872,22 @@ while this is a node-style component:
         \circuitdesc{spdt}{spdt}{}(in/180/0.2, out 1/0/0.2, out 2/0/0.2, mid/90/0.2)
 \end{groupdesc}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) node[spdt] (Sw) {}
   (Sw.in) node[left] {in}
   (Sw.out 1) node[right] {out 1}
   (Sw.out 2) node[right] {out 2}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
  (0,0) to[C] (1,0) to[toggle switch , n=Sw] (2.5,0)
    -- (2.5,-1) to[battery1] (1.5,-1) to[R] (0,-1) -| (0,0)
   (Sw.out 2) -| (2.5, 1) to[R] (0,1) -- (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Cute switches}
 \label{sec:cute-switches}
@@ -6936,7 +6936,7 @@ Additionally, you have the \texttt{cin}, \texttt{cout 1} y \texttt{cout 2} which
 
 For more complex situations, the contact nodes are available\footnote{Thanks to \texttt{@marmot} on \href{https://tex.stackexchange.com/a/492599/38080}{tex.stackexchange.com}.} using the syntax \emph{name of the node}\texttt{-in}, \dots\texttt{-out 1} and \dots\texttt{-out 2}, with all their anchors.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[cute spdt up] (S1) {}
   (S1.in) node[left] {in}
@@ -6948,18 +6948,18 @@ For more complex situations, the contact nodes are available\footnote{Thanks to 
   \draw [red] (S1-in.s) -- (S2-in.n);
   \draw [blue] (S1-out 2.s) -- (S2-out 1.n);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The \texttt{mid} anchor in the cute switches (both path- and node-style) can be used to combine switches to get more complex configurations:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,1.4) node[cute spdt up](S1){};
     \draw (0,0)   node[cute spdt up](S2){};
     \draw (0,-1)  node[cuteclosedswitchshape, yscale=-1](S3){};
     \draw [densely dashed] (S1.mid)--(S2.mid)--(S3.mid);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Cute switches customization}
 \label{par:cute-switches-customization}
@@ -6967,7 +6967,7 @@ The \texttt{mid} anchor in the cute switches (both path- and node-style) can be 
 You can use the key \IndexKey{bipoles/cuteswitch/thickness} to decide the thickness of the switch lever.
 The units are the diameter of the \texttt{ocirc} connector, and the default is \texttt{1}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{bipoles/cuteswitch/thickness=0.5}
     \draw (0,1.4) node[cute spdt up](S1){};
@@ -6975,11 +6975,11 @@ The units are the diameter of the \texttt{ocirc} connector, and the default is \
     \draw (0,-1)  node[cuteclosedswitchshape, yscale=-1](S3){};
     \draw [densely dashed] (S1.mid)--(S2.mid)--(S3.mid);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, the switches are normally drawn using the \texttt{ocirc} shape, but you can change it, as in the following example, with the key \IndexKey{bipoles/cuteswitch/shape}. Be careful that the shape is used with its defaults (which can lead to strange results), and that the standard anchors will be correct only for \texttt{circ} and \texttt{ocirc} shapes, so you have to use the internal node syntax to connect it.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \begin{scope}
         \ctikzset{bipoles/cuteswitch/thickness=0.5,
@@ -6995,7 +6995,7 @@ Finally, the switches are normally drawn using the \texttt{ocirc} shape, but you
     \draw (0,-2)  node[cuteclosedswitchshape, yscale=-1](S3){};
     \draw [densely dashed] (S1.mid)--(S2.mid)--(S3.mid);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Proximity switches}
 \label{sec:proximity-switches}
@@ -7010,7 +7010,7 @@ The \texttt{proximeter} shape\footnote{Suggested by \href{https://github.com/cir
 It has been assigned to the \texttt{switches} class; you can adjust the (relative) thickness of the inside horizontal lines with the key \IndexKey{proximeter/hlines thickness} (default \texttt{0.5}) and their vertical position with \IndexKey{proximeter/hlines position} (default \texttt{0.3}). You can also change the default size of \emph{all} proximeter symbols by changing \IndexKey{proximeter/width} (only safe at picture level; better set in the preamble if you need to change it. The default value is \texttt{0.3}).
 
 Notice in the following example that, as ever for node-type shape, the text is not included in the bounding box:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \tikzset{small up proxi/.style={proximeter, solid,
             circuitikz/switches/scale=0.707,
@@ -7022,7 +7022,7 @@ Notice in the following example that, as ever for node-type shape, the text is n
         node[small up proxi, above](P2p){Fe}
         (P2p.north) ++ (0,0.5); % extend bounding box
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Rotary switches}
 \label{sec:rotary-switches}
@@ -7046,7 +7046,7 @@ To add arrows, you can use the styles \IndexKey{rotary switch -} (no arrow, what
 Notice that the defaults of the styles are the same as the default values of the parameters, but that if you change globally the defaults using the keys mentioned above, you only change the defaults for the ``bare'' component \texttt{rotaryswitch}, not for the styles.
 
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
 \ctikzset{multipoles/rotary/arrow=both}
 \draw (0,0) -- ++(1,0) node[rotary switch <-=8 in 120 wiper 40, anchor=in](A){};
@@ -7057,7 +7057,7 @@ Notice that the defaults of the styles are the same as the default values of the
 \draw (C.out 3) -- ++(1,0) node[rotary switch ->, xscale=-1, anchor=out 3](D){};
 \draw[green, dashed] (B.mid) -- ++(-.5,-1) -| (C.mid);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Rotary switch anchors}
 \label{par:rotary-switch-anchors}
@@ -7106,18 +7106,18 @@ The code for the diagram at the left, above, without the markings for the anchor
 
 One possible application for the angled and the ``on square'' anchors is that you can use them to move radially from the output poles, for example for adding numbers:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[rotary switch=13 in 120 wiper 0](S){};
 \foreach \i in {1,...,13} % requires "calc"
     \path ($(S.aout \i)!1ex!(S.sqout \i)$)
         node[font=\tiny\color{red}]{\i};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, notice that the value of width for the rotary switches is taken from the one for the ``cute switches'' which in turn is taken from the width of traditional  \texttt{spdt} switch, so that they match (notice that the ``center'' anchor is better centered in the rotary switch, so you have to explicitly align them).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[color=blue, rotary switch=2 in 35 wiper 30,
         anchor=in](R){};
@@ -7125,7 +7125,7 @@ Finally, notice that the value of width for the rotary switches is taken from th
     \draw (0,-2) node[color=blue, rotary switch=3 in 35 wiper 30,
         anchor=in](R){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Rotary switch customization}
 \label{par:rotary-switch-customization}
@@ -7133,7 +7133,7 @@ Finally, notice that the value of width for the rotary switches is taken from th
 Apart from the basic customization seen above (number of channels, etc.) you can change, as in the cute switches, the shape used by the connection points with the parameter \IndexKey{multipoles/rotary/shape}, and the thickness of the wiper with \IndexKey{multipoles/rotary/thickness}; if you specify a negative value here, the wiper is not drawn at all\footnote{Suggested by users \texttt{kabenyuk} and \texttt{cis} on TeX-SX.com; see \href{https://tex.stackexchange.com/questions/755499/circuitkiz-customize-the-style-of-the-rotary-switch-position-display}{this question\&answer for an application}.}(but the anchors, and the additional arrow if you specify it, are still there).
 The optional arrow has thickness equal to the standard bipole thickness \texttt{bipoles/thickness} (default 2).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{multipoles/rotary/thickness=0.5}
     \draw (0,2) node[rotary switch ->, color=blue](S1){};
@@ -7144,18 +7144,18 @@ The optional arrow has thickness equal to the standard bipole thickness \texttt{
     \ctikzset{multipoles/rotary/thickness=-1}
     \draw (2,0) node[rotary switch, color=purple](S4){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, the size can be changed using the parameter \IndexKey{tripoles/spdt/width} (default 0.85).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,2) node[rotary switch ->, color=blue](S1){};
     \ctikzset{tripoles/spdt/width=1.6, fill=cyan,
         multipoles/rotary/shape=osquarepole}
     \draw (0,0) node[rotary switch ->](S2){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Switch arrows\label{sec:switcharrows}}
 \label{sec:switch-arrows-sec}
@@ -7165,7 +7165,7 @@ Also you can change the start arrow with the corresponding \IndexKey{switchable 
 
 You can change that globally or locally, as ever. The tip specification is the one you can find in the \TikZ{} manual (``Arrow Tip Specifications'').
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,2) to[cspst] ++(2,0)
         node[cute spdt up arrow, anchor=in]{};
@@ -7174,7 +7174,7 @@ You can change that globally or locally, as ever. The tip specification is the o
         switch start arrow={Bar[red]},
         switch end arrow={Triangle[blue]}]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can also have the option to change the color, relative thickness, and dash pattern  by setting keys with the \verb!\ctikzset! command under the \IndexKey[switch arrows]{switch arrows customization} hierarchy. The available keys are:
 
@@ -7191,7 +7191,7 @@ You can also have the option to change the color, relative thickness, and dash p
     \footnotetext{Follows the syntax of the pattern sequence \texttt{\textbackslash pgfsetdash} --- see \TikZ{} manual for details; phase is always zero. Basically you pass pairs of dash-length -- blank-length dimensions, see the examples.}
 \end{center}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,2) to[spst] ++(1,0) to[cogsw]
     ++(1,0) to[oncs] ++(1,0);
@@ -7201,12 +7201,12 @@ You can also have the option to change the color, relative thickness, and dash p
 \draw (0,0) to[spst] ++(1,0) to[cogsw, switch arrows/dash=none]
     ++(1,0) to[oncs, switch arrows/color=blue] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Rotary switch arrows.} You can change the rotary switch arrow shape in the same way as you change the ones in regular switches. Notice however that if you set either \texttt{switch end arrow} or \texttt{switch start arrow} they will be followed only if you have set both arrows with \texttt{<->} or equivalent, otherwise just one will be used.
 \label{par:rotary-switch-arrows}
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
 \ctikzset{multipoles/rotary/arrow=both}
 \draw (0,0) -- ++(1,0) node[rotary switch <-=8 in 120 wiper 40, anchor=in](A){};
@@ -7222,7 +7222,7 @@ You can also have the option to change the color, relative thickness, and dash p
     \draw (C.out 3) -- ++(1,0) node[rotary switch ->, xscale=-1, anchor=out 3](D){};
 \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Jumpers}
 \label{sec:jumpers}
@@ -7241,7 +7241,7 @@ You can think of jumpers like a kind of switches (they have the same function, j
 
 The \texttt{top arc} anchor can be used to locate the position of the top of the wire (when present). In bare jumper, the anchor is located in the middle of the connectors gap.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8]
     \draw (0,0) to[open jumper, l=J1] ++(2,0)
         to[closed jumper, l_=J2, name=J2] ++(2,0)
@@ -7249,13 +7249,13 @@ The \texttt{top arc} anchor can be used to locate the position of the top of the
     \draw [dashed] (J2.top arc) -- ++(0,0.5)
         node[above] {\tiny open to enable};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Similarly to switches, you have access to the subnodes representing the contacts, to be able to draw wires at different angles.
 
 The kind of poles used in the diagram can be changed with the \verb!\ctikzset! key \IndexKey{bipoles/jumpers/shape}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8]
     \draw (0,0) to[open jumper, l=J1, name=J1] ++(2,0)
         to[closed jumper, l_=J2, name=J2,
@@ -7263,7 +7263,7 @@ The kind of poles used in the diagram can be changed with the \verb!\ctikzset! k
         \draw [red] (J2-in.-135) -- ++(-135:1)
             node[font=\tiny, below]{marked \emph{hot}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Two-ways (three-pins) jumpers.} In this case, the symbol represent two-ways jumpers (normally, three pins that can be connected in a couple of ways).
 \label{par:two-ways-three}
@@ -7280,7 +7280,7 @@ To maintain flexibility, every possible combination of bare, open or closed is a
 
 The option is used as shown in the following example, or by setting the key using \verb!\ctikzset!. The value \textbf{must} be two characters, either two numbers (where \texttt{0} means ``bare'', \texttt{1} means ``open'', and \texttt{2} means ``closed'') or the letter \texttt{S} (for ``span'') and one number. In the latter case, the arc will connect the fist and last pole\footnote{Although really I never saw an example of this use\dots You never know.}
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
     \draw (0,1.5) to[three-pins jumper, l=J1, name=T] ++(3,0)
     to[three-pins jumper, tjumper connections=21, l=J2] ++(3,0)
@@ -7291,7 +7291,7 @@ The option is used as shown in the following example, or by setting the key usin
     to[three-pins jumper, tjumper connections=S1, l=JB] ++(3,0)
     to[three-pins jumper, tjumper connections=S2, l=JB] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Solder jumpers.} Solder jumpers are basically jumpers that can be closed or opened on the printed circuit board. Although electrically they behave exactly as jumpers, these are thought to change configurations in a more stable way (to change them from their default connection you have to use a cutter and/or a soldering iron).
 \label{sec:solder-jumpers}
@@ -7307,7 +7307,7 @@ The option is used as shown in the following example, or by setting the key usin
     \circuitdescbip[cdsjumper]{closed double solder jumper}{Closed double solder jumper}{}
 \end{groupdesc}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=0.8]
     \draw (0,0) to[open solder jumper, l=J1] ++(2,0)
         to[closed solder jumper, l_=J2, name=J2] ++(2,0)
@@ -7315,7 +7315,7 @@ The option is used as shown in the following example, or by setting the key usin
             name=J3] ++(2,0);
     \draw (J3.tap down) -- ++(0,-1) node[ocirc]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Logic gates}
@@ -7411,19 +7411,19 @@ The one-input, one-output ports have a handy path-style equivalent; they are the
 
 Those ports follow the current selected style, although you can change it on the fly (even if it does not have a lot of sense); you can apply labels, annotations and (again, not a lot of sense) voltages to them. The assigned value is typeset as if it were the main text of the node.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \ctikzset{logic ports=ieee}
     \draw (0,0) to[inline not=I1, l=label, v=$\Delta V$] ++(2,0);
     \draw (0,-2) to[inline not, a=ann, european ports] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that in the inline version the leading pins are not drawn,
 so in the case of the transmission gates
 you have to use the border pins to connect the gates.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[ ]
     \ctikzset{logic ports=ieee,
     logic ports/fill=yellow}
@@ -7431,14 +7431,14 @@ you have to use the border pins to connect the gates.
     to[inline double tgate, name=P] ++(3,0)
     (P.bnotgate) |- ++(-3,1);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{American ports usage}
 \label{sec:american-ports-usage}
 
 Since version \texttt{1.0.0}, the default shape of the family of american ``or'' ports has changed to a more ``pointy'' one, for better distinguish them from the ``and''-type ports. You can still go back to the previous aspect with the key \IndexKey{american or shape} that can be set to \texttt{pointy} or \texttt{roundy}. The \texttt{legacy} style will enact the old, roundy style also.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[
     american]
     % legacy shapes
@@ -7457,7 +7457,7 @@ Since version \texttt{1.0.0}, the default shape of the family of american ``or''
         \node [xnor port](O4) at (0,-4.5) {};
     \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{American logic port customization}
 \label{par:american-logic-port}
@@ -7468,19 +7468,19 @@ As for most components, you can change the width and height of the ports; the th
 
 It is possible to change height and width of the logic ports using the parameters \texttt{tripoles/american \emph{type} port/} plus \texttt{width} or \texttt{height}:
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw (0,0) node[nand port] {}; \par
 \ctikzset{tripoles/american nand port/input height=.2}
 \ctikzset{tripoles/american nand port/port width=.4}
 \ctikzset{tripoles/thickness=4}
 \tikz \draw (0,0) node[nand port] {};
-\end{LTXexample}
+\end{ctikzExample}
 
 
 This is especially useful if you have ports with more than two inputs, which are instantiated
 with the parameter \IndexKey{number inputs} :
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,3) node[american and port] (A)  {P1};
 \begin{scope}
@@ -7493,11 +7493,11 @@ with the parameter \IndexKey{number inputs} :
 \draw (0,1.5) node[american or port] (C)  {P3};
 \draw (C.out) |- (B.in 2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can suppress the drawing of the logic ports input leads by using the boolean key \IndexKey{logic ports draw input leads}  (default \texttt{true}) or, locally, with the style \IndexKey{no input leads} (that can be reverted with \IndexKey{input leads}),  like in the following example. The anchors do not change and you have to take responsibility to make the connection to the ``border''-anchors.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \node [or port](O1) at (0,2) {};
     \node [or port, no input leads](O1) at (2,2) {};
@@ -7505,11 +7505,11 @@ You can suppress the drawing of the logic ports input leads by using the boolean
     \node [and port](O1) at (0,0) {};
     \node [nand port, input leads](O1) at (2,0) {};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This is useful if you need to draw a generic port, like the one following here:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{tripoles/american nand port/height=1.6}
     \draw (0,0)
@@ -7520,18 +7520,18 @@ This is useful if you need to draw a generic port, like the one following here:
     \draw (B.in 1) -- (B.bin 1) (B.in 5) -- (B.bin 5);
     \node[rotate=90] at (B.in 3) {\dots};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In an analogous manner, there is a setting \IndexKey{logic ports draw output leads} (and a corresponding style \IndexKey{no output leads}) that suppresses the drawing of the output lead. A shortcut boolean key \IndexKey{logic ports draw leads} will suppress or enable all leads (the corresponding styles are \IndexKey{no leads} and \IndexKey{all leads}).
 
 You can tweak the appearance of american ``or'' family (\texttt{or}, \texttt{nor}, \texttt{xor}  and \texttt{xnor}) ports, too, with the parameters \texttt{inner} (how much the base circle goes ``into'' the shape, default 0.3) and \texttt{angle} (the angle at which the base starts, default 70).
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw (0,0) node[xnor port] {};
 \ctikzset{tripoles/american xnor port/inner=.7}
 \ctikzset{tripoles/american xnor port/angle=40}
 \tikz \draw (0,0) node[xnor port] {};
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{American logic port anchors}
 \label{par:american-logic-port-anchors}
@@ -7581,7 +7581,7 @@ You also have ``border pin anchors'':
 
 These anchors are especially useful if you want to negate inputs:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,3) node[american and port] (A)  {P1};
 \node at (A.bin 1) [ocirc, left]{} ;
@@ -7595,10 +7595,10 @@ These anchors are especially useful if you want to negate inputs:
 \node at (C.bin 2) [ocirc, left]{} ;
 \draw (C.out) |- (B.in 2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 As you can see, the \texttt{center} anchor is (for historic reasons) not in the center at all. You can fix this with the command \IndexKey[logic ports origin]{}\verb|\ctikzset{logic ports origin=center}|:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{logic ports origin=center}
 \draw (0,0) node[and port] (myand)  {}
@@ -7608,9 +7608,9 @@ As you can see, the \texttt{center} anchor is (for historic reasons) not in the 
 \draw[<-] (myand.center) -- ++(1,-1)
    node{center};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,2) node[and port] (myand1)  {}
   (0,0) node[and port] (myand2)  {}
@@ -7618,11 +7618,11 @@ As you can see, the \texttt{center} anchor is (for historic reasons) not in the 
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In the case of \textsc{not}, there are only \texttt{in} and \texttt{out} (although for compatibility reasons \texttt{in 1} is still defined and equal to \texttt{in}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (1,0) node[not port] (not1)  {}
   (3,0) node[not port] (not2)  {}
@@ -7631,11 +7631,11 @@ In the case of \textsc{not}, there are only \texttt{in} and \texttt{out} (althou
   ++(0,-1) node[ground] {} to[C] (not1.out)
   (not2.out) -| (4,1) -| (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This last circuit could be drawn also (and probably in a more natural manner) using the path-style components:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) node[ground]{} to[C] ++(0,1.5)
     coordinate(c)
@@ -7643,7 +7643,7 @@ This last circuit could be drawn also (and probably in a more natural manner) us
     -| ++(-5,-1)
     to[inline not] (c);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{IEEE logic gates usage.}
 \label{sec:ieee-logic-gates}
@@ -7654,28 +7654,28 @@ The rest of this section will assume you have issued the command \verb|\ctikzset
 
 IEEE standard logic gates have a basic difference with the legacy ones: the proportions of their shapes do not change when you change the size, so you can't have a ``tall'' port or a ``squatty'' one. The two-inputs gates, by default, have their default size designed so that they match the chips component (see~\ref{sec:chips}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you need, say\IndexKey[logic gates, ieee, multiple inputs]{}, a 4-inputs port, the port will look like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1, number inputs=4,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \dots and in this case it is clear that it does not match. With standard ports, there are two possibilities.
 The first one is to scale the port; if you set the port height so that it has the same size (see ``IEEE logic gates customization'' below for details)  as the number of ports, they will match again.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1,
@@ -7683,11 +7683,11 @@ The first one is to scale the port; if you set the port height so that it has th
         circuitikz/ieeestd ports/height=4,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 But then the size of the port is quite ``unusual''. The solution in technical literature is to use what we can call a ``rack'' for the inputs; basically, only a certain number of pins are kept on the port, and the others are put on an extended input line.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1,
@@ -7695,7 +7695,7 @@ But then the size of the port is quite ``unusual''. The solution in technical li
         inner inputs=2,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 When using the \IndexKey{inner inputs} key, keep in mind the rule of thumbs:
 \begin{itemize}
@@ -7704,7 +7704,7 @@ When using the \IndexKey{inner inputs} key, keep in mind the rule of thumbs:
 \end{itemize}
 For example, look at the following example; given that we are asking an odd number of pins on the rack, some of the inputs are drawn on the port's border, resulting in a less-than-ideal diagram.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1,
@@ -7712,11 +7712,11 @@ For example, look at the following example; given that we are asking an odd numb
         inner inputs=2,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In this case, if you don't like the solution, the better approach is to let the gate grow a bit.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip](C){IC} (C.pin 8)
         node[or port, anchor=in 1,
@@ -7725,20 +7725,20 @@ In this case, if you don't like the solution, the better approach is to let the 
         circuitikz/ieeestd ports/height=3,
         color=red](A){IC2A};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The good thing about the rack mechanism is that you can have quite big ports without problems.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}[scale=0.75, transform shape]
     \draw node[nor port, number inputs=32, inner inputs=2,
                rotate=90](A){\rotatebox{-90}{IC1A}};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use the additional elements (the \texttt{notcirc} and the \texttt{schmitt symbol} to obtain circuits like the following ones (well, a bit of a mix of conventions, but...):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[and port](A){A} (A.out)
     node[buffer port, anchor=in,
@@ -7749,7 +7749,7 @@ You can use the additional elements (the \texttt{notcirc} and the \texttt{schmit
     \node [notcirc, above](C) at (B.up) {};
     \draw (C.north) |- ++(-1,1) (B.down) --++(0,-1);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice the key \IndexKey{component text=left} that moves the label near to the left border of the component. There is also a \verb|\ctikzset{component text=left}| if you prefer to have it as a default for all the IEEE ports.\footnote{You can use the same key with amplifiers, too.}
 
@@ -7757,7 +7757,7 @@ Notice the key \IndexKey{component text=left} that moves the label near to the l
 \paragraph{Stacking and aligning IEEE standard gates.} The standard gates are designed so that they stacks up nicely when positioned using the external leads as anchors. Notice that the ports \textbf{do} have different sizes, but the leads lengths are designed to counter the differences.
 \label{par:stacking-and-aligning}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw
     (0,0) node[and port, anchor=in 1]{A1}
@@ -7772,13 +7772,13 @@ Notice the key \IndexKey{component text=left} that moves the label near to the l
     \draw[red, dashed]([yshift=0.8cm]A1.body left)
         -- ([yshift=-0.8cm]A4.body left);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The length of the external leads can be changed by the user, but notice that if you use a too small value you can jeopardize that property.
 
 The single input ports (\texttt{not port}, \texttt{buffer port} and their Schmitt equivalent) are smaller than the six standard ports, so they are not kept aligned by default; the just have the same distance at the input side. For the not ports, the \texttt{left} position of the text results often in a better look (the centered text in the triangle seems to be much more at the right).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{component text=left}
     \draw (0,0) node[nand port, anchor=in 1]{A1}
@@ -7790,7 +7790,7 @@ The single input ports (\texttt{not port}, \texttt{buffer port} and their Schmit
     \draw[red, dashed]([yshift=0.8cm]A1.body left)
         -- ([yshift=-0.8cm]A3.body left);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{IEEE standard ports customization}
 \label{par:ieee-standard-ports}
@@ -7815,7 +7815,7 @@ There are several parameters that can be used to customize the IEEE standard por
 
 For example, using a \IndexKey{not radius} of \texttt{0.1} will give a ``not ball'' of the same size of a connecting pole, as it is in the legacy ports.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,2) node[xnor port](P){}
         (P.out) to[short, -o] ++(1,0);
@@ -7824,28 +7824,28 @@ For example, using a \IndexKey{not radius} of \texttt{0.1} will give a ``not bal
     \draw (0,0) node[xnor port](P){}
         (P.out) to[short, -o] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In addition to the specific parameters, you can also apply to these ports the boolean style \IndexKey{no input leads}  as in legacy ones (this simply \emph{does not draw} the input leads, but the anchors stays where they should):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \draw (0,0) node[nand port,
       number inputs=5, no input leads,](B){Pn};
 \draw (B.in 1) -- (B.bin 1) (B.in 5) -- (B.bin 5);
 \node[rotate=90] at (B.in 3) {\dots};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Changing the leads length must be done with a bit of care, because if the length is shorter than the port left or right extrusions strange things can happen (yes, a 4-inputs xnor gates is not so well defined\dots but it's a nice example to show):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{ieeestd ports/pin length=0.2}
     \draw (0,0) node[xnor port,
       number inputs=4, inner inputs=2](B){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{IEEE standard ports anchors} Geographical anchors define the rectangular space that the port is using, included the leads if presents.
 \label{par:ieee-standard-ports-anchors}
@@ -7908,13 +7908,13 @@ Finally, the internal \texttt{notcirc} node used for the output negation is acce
 The \texttt{tgate} and \texttt{double tgate} components are available since \texttt{1.2.4} but only in the IEEE style. An additional parameter \IndexKey{tgate scale} (default \texttt{0.7}; if you set this to \texttt{1} the triangles will have the same size as a \texttt{ieeestd buffer port}) select the relative scale of the components.
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{logic ports=ieee}
     \draw (0,0) to[inline not, *-*] ++(2,0)
     node[tgate, anchor=in]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The anchors for the tgate's control point are called \texttt{gate} and \texttt{notgate} (and the corresponding \texttt{bgate} and \texttt{bnotgate} for the border anchors).
 
@@ -7955,7 +7955,7 @@ European logic port are in the same class as american and IEEE-style ones, and t
 The standard text inside the port does not rotate (not flip) with the component\footnote{since \texttt{1.6.4}, thanks to a suggestion by \href{https://github.com/circuitikz/circuitikz/issues/730}{user \texttt{@sputeanus} on GitHub}.}, but you can change the font (and color and so on) with the key \IndexKey{european ports font} (default nothing, which means it uses the standard font and color).
 For more complex customization, you can use the two ``blank'' European ports, and add the text you want on them.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \ctikzset{
         logic ports=european,
@@ -7973,12 +7973,12 @@ For more complex customization, you can use the two ``blank'' European ports, an
         ]{\rotatebox{-90}{\Huge ?}};
     \draw(3,-3) node [blank not port, xscale=-1]{?};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{European logic port customization} Normally the European-style logic port with inverted output are marked with a small triangle; if you want you can change it with the key \IndexKey{tripoles/european not symbol}; its default is \texttt{triangle} but you can set it to \texttt{circle} like in the following example. As you can see, the circle size is the same as the circuit poles; if you prefer the size used in the IEEE standard ports, you can use set it to \texttt{ieee circle}.
 \label{par:european-logic-port}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \draw (0,3) node[nand port](A){}
         (A.out) to[short, *-o] ++(0.5,0);
@@ -7989,18 +7989,18 @@ For more complex customization, you can use the two ``blank'' European ports, an
     \draw (0,0) node[european nand port](A){}
         (A.out) to[short, *-o] ++(0.5,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In some standard, the \texttt{xnor} port is different --- without the negation at the end and with just an $=$ sign.\footnote{Suggested by user \texttt{Schlepptop} on GitHub.}
 You can switch to this if you like, with the key \IndexKey{european xnor style} that can be \texttt{default} or \texttt{direct}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \draw (0,0) node[xnor port]{};
     \ctikzset{european xnor style=direct}
     \draw (3,0) node[xnor port]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{European logic port anchors} The anchors are basically the same as in the american-style ports.
 \label{par:european-logic-port-anchors}
@@ -8055,12 +8055,12 @@ To set all these keys, an auxiliary style \IndexKey{flipflop def} is defined, so
 
 \begingroup
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \tikzset{flipflop AB/.style={flipflop,
     flipflop def={t1=A, t3=B, t6=Q, t4={\ctikztextnot{Q}},
         td=rst, nd=1, c2=1, n2=1, t2={\texttt{CLK}}},
 }}
-\end{LTXexample}
+\end{ctikzExample}
 
 to obtain:
 
@@ -8103,11 +8103,11 @@ If you like different pin distributions, you can easily define different flip-fl
 
 \begingroup
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \tikzset{flipflop myJK/.style={flipflop,
     flipflop def={t1=J, t2=K, t6=Q, t4={\ctikztextnot{Q}}, c3=1}}
 }
-\end{LTXexample}
+\end{ctikzExample}
 
 \begin{groupdesc}
     \circuitdesc*{flipflop myJK}{Example custom flip flop}{}
@@ -8168,7 +8168,7 @@ As in chips, you can change the length of the external pin with the key \IndexKe
 Notice however that negated pins when the pins width is zero has to be handled with care. As explained in the poles sections, the \texttt{ocirc} shape is drawn at the end of the shape to cancel out the wires below; so if you use a pinless flipflop when you make the connection you should take care of connecting the symbol correctly. To this end, the shapes of the negation circles are made available as \texttt{\textsl{<nodename>}-N\textsl{<pin number>}}, as you can see in the next (contrived) example.
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[scale=3, transform shape]
     \clip (0.2,0.5) rectangle (1.2,-1.3);
     \node [flipflop JK,
@@ -8178,21 +8178,21 @@ Notice however that negated pins when the pins width is zero has to be handled w
     \draw (A-N5.east) -- ++(1,0); % correct
     \draw (A.pin 4) -- ++(1,0);   % wrong
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Normally the symbols on the flip-flop are un-rotated when you rotate the symbol, but as in case of chips, you can avoid it.
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \begin{tikzpicture}
     \draw (0,0) node[flipflop JK, add async SR]{};
     \draw (3,0) node[flipflop JK, add async SR, rotate=90]{};
     \draw (7,0) node[flipflop JK, add async SR, rotate=90, rotated numbers]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can also change the size of the wedge, with the key \IndexKey{multipoles/flipflop/clock wedge size} (default value \texttt{0.2}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}[]
     \draw (0,0) node[flipflop JK]{JK};
     \ctikzset{multipoles/flipflop/clock wedge size=0.1}
@@ -8200,11 +8200,11 @@ You can also change the size of the wedge, with the key \IndexKey{multipoles/fli
     \ctikzset{multipoles/flipflop/clock wedge size=0.4}
     \draw (4.6,0) node[flipflop JK]{JK};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Flip-flops ``not circles'' follows the current logic port setting (either if you choose \texttt{ieee ports}, or if you are using \texttt{european ports} with \texttt{european not symbol} set to \texttt{cirle} or \texttt{ieee circle}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
 \ctikzset{logic ports=european,
     tripoles/european not symbol=ieee circle}
@@ -8217,7 +8217,7 @@ tripoles/european not symbol=circle}
     (A.out) to[short] ++(0.5,0)
     node[flipflop JK, dot on notQ, anchor=pin 2]{JK};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Multiplexer and de-multiplexer}\label{sec:muxdemuxes}
@@ -8311,7 +8311,7 @@ The default values are $\texttt{Lh}=8$, $\texttt{Rh}=6$, $\texttt{w}=3$ and no i
 \end{description}
 All the distances are multiple of \IndexKey{multipoles/muxdemux/base len} (default \texttt{0.4}, to be set with \verb|\ctikzset|), which is relative to the basic length. That value has been chosen so that, if you have a number of pins which is equal to the effective distance where they are spread (which is \texttt{Lh} without inset, $\texttt{Lh}- (\texttt{inset Lh})$ with an inset), then the distance is the same as the default pin distance in chips, as shown in the next circuit. In the same drawing you can see the effect of \texttt{square pins} parameters (without it, the rightmost bottom lead of the \texttt{mux 4by2} shape will not connect with the below one).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \tikzset{mux 4by2/.style={muxdemux,
         muxdemux def={Lh=4, NL=4, Rh=3,
@@ -8324,7 +8324,7 @@ All the distances are multiple of \IndexKey{multipoles/muxdemux/base len} (defau
     \node [qfpchip, num pins=8, anchor=pin 8] at
         (B.bpin 1) {IC2};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Mux-Demux customization}
 \label{sec:mux-demux-customization}
@@ -8353,7 +8353,7 @@ pins are drawn. The anchors will be adjusted, such that each \texttt{\emph{x}pin
 \textit{n}} will be placed at the end of the pins which are drawn, and coincide
 with the \texttt{b\emph{x}pin \textit{n}} anchors for the suppressed pins.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
     \node [muxdemux, muxdemux def={NL=4, NR=3, NT=5, NB=3, w=2,
             inset w=0.5, Lh=4, inset Lh=2.0, inset Rh=1.0,
@@ -8362,7 +8362,7 @@ with the \texttt{b\emph{x}pin \textit{n}} anchors for the suppressed pins.
         draw only top pins={1-3},
         draw only bottom pins={3}](C) at (0,0) {X};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Mux-Demux anchors}
 \label{sec:mux-demux-anchors}
@@ -8439,7 +8439,7 @@ All of these labels and symbols are added by specifying them in a \IndexKey[muxd
 \paragraph{Inner pin labels} will be printed in the inside of the shape, with the font specified in the \verb|\ctikzset| key \IndexKey{muxdemux/inner label font} (default is \verb|\tiny| in \LaTeX, other engine can have it different --- better set it in case of doubt) and with a padding setting with the keys \IndexKey{muxdemux/inner label xsep} and  \IndexKey{muxdemux/inner label ysep} (respectively for horizontal and vertical shifts; default for both \texttt{2pt}). You can also use the key \IndexKey{muxdemux/inner label sep} to set both at the same time.
 \label{par:inner-pin-labels}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \tikzset{myICwl/.style={muxdemux,
     muxdemux def={Lh=4, Rh=4, w=4,
@@ -8454,12 +8454,12 @@ All of these labels and symbols are added by specifying them in a \IndexKey[muxd
     node[myICwl, rotate=-90,
         rotated numbers]{chip};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As you can see, the syntax is to add a \texttt{muxdemux label} to the specification; the labels are set using one of the letter \texttt{L}, \texttt{R}, \texttt{B}, and \texttt{T} for respectively left, right, bottom and top labels. You can define all the labels, none (which will give the default behavior of no-labels as it was before \texttt{v1.6.5}), or any number you wish.
 If you want some specific label rotated in a different way, you have to do it manually, as shown in the following example.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \tikzset{mux 4by2 wl/.style={muxdemux,
     muxdemux def={Lh=6, NL=6, Rh=3, NB=2, w=3, NT=1},
@@ -8470,12 +8470,12 @@ If you want some specific label rotated in a different way, you have to do it ma
     circuitikz/muxdemux/inner label ysep=4pt}}
 \node [mux 4by2 wl]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Outer pin labels} will be printed on the outside of the pin position --- in the case of left and right pins, either above (``up'', identified by \texttt{LU} and \texttt{RU} labels), or below (``down'', \texttt{LD} and \texttt{RD} labels); in the case of top and bottom pin, either at the left (\texttt{TL} and \texttt{BL}) or at the right (\texttt{TR} and \texttt{BR}). The font is specified in the key \IndexKey{muxdemux/outer label font} (default \verb|\tiny|) and the padding with the corresponding \IndexKey{muxdemux/outer label xsep} and  \IndexKey{muxdemux/outer label ysep} (default for both \texttt{2pt}), or \IndexKey{muxdemux/outer label sep} to set both at the same time.
 \label{par:outer-pin-labels}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{muxdemux/outer label
     font={\tiny\ttfamily\color{blue}}}
@@ -8495,13 +8495,13 @@ If you want some specific label rotated in a different way, you have to do it ma
     node[myICwl, rotate=-90,
         rotated numbers]{chip};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \paragraph{Border labels} are drawn \emph{before} the other labels along the external border (to be exact: in north, south, east, and west position) of the component.
 \label{par:border-labels}
 You set them with the key \texttt{N}, \texttt{S}, \texttt{W}, and \texttt{E} for the outer position, and \texttt{Ni}, \texttt{Si}, \texttt{Wi}, and \texttt{Ei} for the inner ones.
 The font is specified in the key \IndexKey{muxdemux/border label font} (default \verb|\tiny|) and the padding with the corresponding \IndexKey{muxdemux/border label xsep} and  \IndexKey{muxdemux/border label ysep} (default for both \texttt{2pt}), or \IndexKey{muxdemux/border label sep} to set both at the same time.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{muxdemux/outer label
     font={\tiny\ttfamily\color{blue}}}
@@ -8517,7 +8517,7 @@ The font is specified in the key \IndexKey{muxdemux/border label font} (default 
 \draw (0, -3) node[myICwl,
     muxdemux label={N=another}]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As you can see, you can locally change any label in a specific instance.
 
@@ -8531,7 +8531,7 @@ As you can see, you can locally change any label in a specific instance.
 \end{description}
 The value of the key should be \texttt{0}  or \texttt{1} for clocks and not circles; zero means ``do not draw'' and is used to override a previously specified element. In the case of wedge-style not, the \texttt{-1} value flips the side of the triangle (see the following example).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \ctikzset{muxdemux/outer label
     font={\tiny\ttfamily\color{blue}}}
 \ctikzset{logic ports=ieee, multipoles/external pins width=0.3}
@@ -8546,7 +8546,7 @@ The value of the key should be \texttt{0}  or \texttt{1} for clocks and not circ
         RU1={3\strut}, cL2=0}](A){};
 \draw[red, <-] (A-nL1.-135) -- ++(-135:0.3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As you can see, the label position is not affected (with the exception of the clock wedge, that displaces the inner label), so you have to manually take care of not having overruns; you can change the \texttt{xsep} or \texttt{ysep} or, as shown in the example, modify the heigh and depth of the affected labels.
 
@@ -8559,7 +8559,7 @@ To add the wedge symbol, the \texttt{wedgeinv} shape will nicely do. It'll scale
 
 Similarly, there is also a \texttt{circleinv} shape, which is basically the same as the \texttt{notcirc} (see~\ref{sec:ieeestdports}) one, but that scales with the \texttt{muxdemuxes} class and that has the default anchor at its left, similarly to \texttt{wedgeinv}. This one will be filled if the class says so, contrary to the wedge-like shapes that are always open.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \path (0,4) node[muxdemux, muxdemux def={NL=2,Lh=2,Rh=2,NB=1},
         external pins width = 0.5](mdemux){};
@@ -8578,14 +8578,14 @@ Similarly, there is also a \texttt{circleinv} shape, which is basically the same
     \draw (mdemux.blpin 1) node[circleinv,anchor=apex]{};
     \draw (mdemux.brpin 1) node[circleinv]{};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Adding a background drawing to the muxdemux}
 \label{sec:adding-a-background}
 
 In a similar way to the oscilloscope waveform, you can add a drawing to the \texttt{muxdemux} component, provided you use basic-level \texttt{pgf} commands. You have to define a \texttt{.code} key named \IndexKey[muxdemux bgpicture]{bgpicture} in the \texttt{muxdemux def} definitions, as in the following example. The coordinate system is changed so that the horizontal axis of the shape is mapped between \SI{-1}{\cm} and \SI{+1}{\cm} and the origin at the center; the vertical extent will then depend on the form factor of the \texttt{muxdemux}: for example, the vertical coordinate of the top left border will be $\SI{1}{\cm}\cdot{\mathtt{Lh}/\mathtt{w}}$.
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily, keepspaces=true]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily, keepspaces=true]
 \begin{circuitikz}
 \ctikzset{muxdemux/outer label font={\tiny\ttfamily\color{blue}}}
 \tikzset{myICwl/.style={muxdemux,
@@ -8603,11 +8603,11 @@ In a similar way to the oscilloscope waveform, you can add a drawing to the \tex
 }
 \draw (0, 0) node[myICwl]{}{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can even embed images:
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily]
 \begin{circuitikz}
 \ctikzset{muxdemux/outer label font={\tiny\ttfamily\color{blue}}}
 \tikzset{myICwl/.style={muxdemux,
@@ -8621,7 +8621,7 @@ You can even embed images:
 }
 \draw (0, 0) node[myICwl]{}{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 For more complex things, consider using a normal macro that draws on the background layer and that use the geographical coordinates of the node to locate it.
@@ -8634,7 +8634,7 @@ You can use these shapes  to draw a lot of symbols that are unavailable; using a
 
 As an additional example, this was used before the introduction of the \texttt{double tgate} symbol in \texttt{1.2.4} (see ~\ref{sec:passgate}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \def\tgate#1{
     node[simple triangle, anchor=left, no input leads](#1-LR){}
     (#1-LR.right) node[simple triangle, xscale=-1,
@@ -8647,11 +8647,11 @@ As an additional example, this was used before the introduction of the \texttt{d
     \draw (0,0) \tgate{A} (0,-2) \tgate{B};
     \draw (A-RL.bpin 1) -- (B-RL.tpin 1);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Finally, you can play with them to create chips that have generic numbers of pins on the four sides, as in the following example (asked on \href{https://tex.stackexchange.com/q/596320/38080}{TeX.Stackexchange}; notice however that this example has been made \emph{before} the option for labels existed; it could be quite streamlined now, as shown later):
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily]
 \begin{tikzpicture}[scale=0.7, transform shape]
     \tikzset{ic555/.style={muxdemux,
             muxdemux def={Lh=10, NL=5, Rh=10, NR=5, NB=2, w=6, NT=2,
@@ -8680,11 +8680,11 @@ Finally, you can play with them to create chips that have generic numbers of pin
     \draw (A.rpin 3) -- (A.brpin 3)
         node[midway, blue, font=\small, above]{3};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 In a version of \Circuitikz{} better or equal to \texttt{v1.6.5}, you can do this:
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily]
 \begin{tikzpicture}[scale=0.7, transform shape]
 \ctikzset{muxdemux/inner label font=\small}
 \ctikzset{muxdemux/outer label font={\small\color{blue}}}
@@ -8700,7 +8700,7 @@ In a version of \Circuitikz{} better or equal to \texttt{v1.6.5}, you can do thi
     \node [ic555, font=\small\ttfamily,align=center](A)
         at (0,0) {555\\Astable};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Chips (integrated circuits)}\label{sec:chips}
@@ -8731,7 +8731,7 @@ Moreover, you can transform the thin lead into a pad by setting the key \IndexKe
 
 You can, if you want, avoid printing the numbers of the pin with \IndexKey{hide numbers} (default \IndexKey{show numbers}) if you prefer positioning them yourself (see the next section for the anchors you can use).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \ctikzset{multipoles/thickness=4}
         \ctikzset{multipoles/external pins thickness=2}
@@ -8745,14 +8745,14 @@ You can, if you want, avoid printing the numbers of the pin with \IndexKey{hide 
           \node [right, font=\tiny]
           at (C.bpin 1) {RST};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 Also, you can suppress the drawing of the pins, by using the style \IndexKey{no input leads} (that can be reverted with \IndexKey{input leads}). The main difference between setting \texttt{external pins width} to \texttt{0} or using \texttt{no input lead} is that in the first case the normal pin anchors and the border anchors will coincide, and in the second case they will not move and stay where they should have been if the leads were drawn.
 
 For special use you can suppress the orientation mark with the key \IndexKey{no topmark} (default \IndexKey{topmark}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \draw (0,0) node[dipchip,
           num pins=8, no topmark,
@@ -8760,11 +8760,11 @@ For special use you can suppress the orientation mark with the key \IndexKey{no 
         \draw (C.pin 1) -- ++(-0.5,0) to[R]
           ++(0,-1.5) node[ground]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The font used for the pins is adjustable with the key \IndexKey{multipoles/font} (default \verb|\tiny|)
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \ctikzset{multipoles/font={\color{red}\tiny}}
         \draw (0,0) node[qfpchip,
@@ -8773,7 +8773,7 @@ The font used for the pins is adjustable with the key \IndexKey{multipoles/font}
         \draw (C.pin 1) -- ++(-0.5,0) to[R]
           ++(0,-2) node[ground]{};
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can draw only selected pins and leave out the rest by setting
 \IndexKey{multipoles/draw only pins}\footnote{Added by
@@ -8788,7 +8788,7 @@ pins are drawn. The anchors will be adjusted, such that each \texttt{pin
 with the \texttt{bpin \textit{n}} anchors for the suppressed pins.
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \draw (0,3) node[dipchip,
         num pins=8,
@@ -8806,7 +8806,7 @@ with the \texttt{bpin \textit{n}} anchors for the suppressed pins.
             \draw[blue] (Q.bpin \x) circle[radius=1pt];
         }
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Chip anchors}
 \label{sec:chip-anchors}
@@ -8849,7 +8849,7 @@ Additionally, you have geometrical anchors on the chip ``box'', see the followin
 You can rotate chips, and normally the pin numbers are kept straight (option \IndexKey{straight numbers}, which is the default), but you can rotate them if you like with \IndexKey{rotated numbers}.
 Notice that the main label has to be (counter-) rotated manually in this case.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[dipchip,
         rotate=90]{%
@@ -8858,7 +8858,7 @@ Notice that the main label has to be (counter-) rotated manually in this case.
         rotated numbers,
         rotate=45]{IC3};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Chip special usage}
 \label{sec:chip-special-usage}
@@ -8866,7 +8866,7 @@ Notice that the main label has to be (counter-) rotated manually in this case.
 You can use chips to have special, personalized blocks.
 Look at the following example, which is easily put into a macro.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{multipoles/thickness=3}
     \ctikzset{multipoles/dipchip/width=2}
@@ -8886,7 +8886,7 @@ Look at the following example, which is easily put into a macro.
     \draw (C.n) -- ++(0,1) node[vcc]{};
     \draw (C.s) -- ++(0,-1) node[ground]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Seven segment displays}
 \label{sec:seven-segment-displays}
@@ -8899,14 +8899,14 @@ The seven-segment display\IndexKey[seven-segment display]{}\IndexKey[7-segment d
 
 The main ``bare'' component is the one shown above, but for simplicity a couple of style interfaces are defined:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) node[seven segment val=A dot off box on]{};
     \draw (1,0) node[seven segment val=- dot none box on]{};
     \draw (0,-2) node[seven segment bits=1001001 dot empty box on]{};
     \draw (1,-2) node[seven segment bits=0011101 dot none box off]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 There are two main configuration methods. The first one is \IndexKey{seven segment val}, which will take an hexadecimal number or value and display it: the possible values are \texttt{0,...,15}, plus \texttt{A, B, C, D, E, F} (or lowercase) and the symbol \texttt{-} (minus).
 
@@ -8955,7 +8955,7 @@ You can change several parameters to adjust the displays:
 
 A couple of examples are shown below.
 
-\begin{LTXexample}[varwidth=true, pos=b]
+\begin{ctikzExample}[varwidth=true, pos=b]
 \begin{circuitikz}[scale=0.5]
 \ctikzset{seven seg/width=0.2, seven seg/thickness=2pt}
 \foreach \i in {0,...,15} \path (\i,0)
@@ -8967,7 +8967,7 @@ A couple of examples are shown below.
 \foreach \i in {0,...,15} \path[color=red] (\i,-3)
     node[seven segment val=\i dot none box on, xslant=0.2]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -8976,50 +8976,50 @@ A couple of examples are shown below.
 
 You can add ``decorations'' to the path-style components; there are basically five types of them: labels, annotations, voltages, currents, and flows. Let's see an example of all of them\dots
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, l=$R_1$, f=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R=$R_1$, a=\SI{1}{\kohm}] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, v=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R=$R_1$, i=$i_1$, v=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R=$R_1$, i=$i_1$, v=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Long names/styles for the bipoles can be used, of course, and there is a special syntax (that works only in simple cases, and only with \LaTeX{} --- use it with caution!) if you load the package with the \IndexKey{siunitx} options:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}\draw
   (0,0) to[resistor=1<\kilo\ohm>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Labels and Annotations}
 \label{sec:labels-and-annotations}
@@ -9029,25 +9029,25 @@ Since Version 0.7, beside the original label (\IndexKey[l (label)]{l})  option, 
 \label{sec:label-and-annotation}
 When drawing a component left-to-right, the label \texttt{l} is by default above the component, and the annotation \texttt{a} is by default below it. The position of annotations and labels can be adjusted adding the characters \verb|_| or \verb|^| to the key.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, l=$R_1$,a=1<\kilo\ohm>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, l_=$R_1$,a^=1<\kilo\ohm>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 For passive components, you can use \texttt{\emph{component type}=text} as a shortcut for \texttt{\emph{component type}, l=text}:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R=$R_1$,a=1<\kilo\ohm>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice though that in active component (sources of either voltage or current) the shortcut will set the voltage (\IndexKey[v (voltage)]{v}) or current (\IndexKey[i (current)]{i}) property.
 
@@ -9055,14 +9055,14 @@ Notice though that in active component (sources of either voltage or current) th
 Normally the package will guess a good position for the label or annotation; if you do not like it,
 you can add\footnote{Since version \texttt{1.3.3}} (or remove, with negative values) distance using the \verb|\ctikzset| keys \IndexKey{label distance} and \IndexKey{annotation distance}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[sR, l=$R$, label distance=-4pt] (2,0)
     to [sR, l=$R$] (4,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \ctikzset{bipoles/inductors/core distance=4pt}
     \draw (0,1) to[L=$L$, name=myL] ++(2,0);
@@ -9070,13 +9070,13 @@ you can add\footnote{Since version \texttt{1.3.3}} (or remove, with negative val
     \draw (0,0) to[L=$L$, name=myL, label distance=2pt] ++(2,0);
     \draw[thick, double] (myL.core west) -- (myL.core east);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Special symbols in labels and annotations.}\label{sec:bracing-of-labels}
 When \TikZ{} processes the options, there will be problems if the label (or annotation, voltage, or current) contains one of the characters $=$ (equal) or $,$ (comma) --- because the parser search for those two characters to delimit the arguments, giving unexpected errors and wrong output.
 These two characters can be protected from the option parser using an extra set of braces.
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         % the following will fail:
         % \draw (0,0) to[R, l=$R=3$]
@@ -9086,11 +9086,11 @@ These two characters can be protected from the option parser using an extra set 
         % this works, but it has wrong spacing
         \draw (0,3) to[R, l=$R{=}3$] (3,3);
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \textbf{Caveat:} up to version \texttt{1.2.7}, due to the way in which \Circuitikz{} used to processes the options, even that was not sufficient, so you must protect that tokens even more, for example using an \verb|\mbox| command, or redefining the characters with a \TeX\ \verb|\def|:
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{circuitikz}
         \def\eq{=}
         % the following will fail up to 1.2.7:
@@ -9101,13 +9101,13 @@ These two characters can be protected from the option parser using an extra set 
         % this works, but it has wrong spacing
         \draw (0,3) to[R, l=$R{=}3$] (3,3);
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Labels and annotation orientation.}
 \label{sec:labels-and-annotation}
 The default orientation of labels is controlled by the options \IndexKey{smartlabels}, \IndexKey{rotatelabels} and \IndexKey{straightlabels} (or the corresponding \IndexKey{label/align} keys). Here are examples to see the differences:
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{label/align = straight}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
@@ -9115,8 +9115,8 @@ The default orientation of labels is controlled by the options \IndexKey{smartla
   \draw (0,0) to[R=\i, *-o] (\i:2.5);
 }
 \end{circuitikz}
-\end{LTXexample}
-\begin{LTXexample}
+\end{ctikzExample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{label/align = rotate}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
@@ -9124,8 +9124,8 @@ The default orientation of labels is controlled by the options \IndexKey{smartla
   \draw (0,0) to[R=\i, *-o] (\i:2.5);
 }
 \end{circuitikz}
-\end{LTXexample}
-\begin{LTXexample}
+\end{ctikzExample}
+\begin{ctikzExample}
 \begin{circuitikz}
 \ctikzset{label/align = smart}
 \def\DIR{0,45,90,135,180,-90,-45,-135}
@@ -9133,7 +9133,7 @@ The default orientation of labels is controlled by the options \IndexKey{smartla
   \draw (0,0) to[R=\i, *-o] (\i:2.5);
 }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Stacked (two lines) labels.}
 \label{sec:stacked-two-lines}
@@ -9153,7 +9153,7 @@ The \texttt{l2} and \texttt{a2} will only work in LaTeX because they use a \text
 %     \draw (0,2) to [R, l2= {A=B} and X, l2 valign=b, l2 halign=c] ++(2,0) to[L, l2=A and X \\ {C=Z}] ++(0,-2);
 % \end{circuitikz}
 
-\begin{LTXexample}[varwidth=true, pos=t, keepspaces, basicstyle=\footnotesize\ttfamily]
+\begin{ctikzExample}[varwidth=true, pos=t, keepspaces, basicstyle=\footnotesize\ttfamily]
 \begin{circuitikz}[american]
     %
     % default for l2 is: l2 halign=l, l2 valign=c. DO NOT USE the <...> notation
@@ -9168,7 +9168,7 @@ The \texttt{l2} and \texttt{a2} will only work in LaTeX because they use a \text
     \draw (5,0) to[R, l2^=$R_{CC}$ and \SI{4.7}{k\ohm}, l2 halign=c, l2 valign=t] ++(0,-2);
     \draw (10,2) to[R, l2={A=B} and X, a2={C=D} and Y] ++(0,-4);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 For extra options about labels and annotations, please refer to section~\ref{sec:ornament-style}
 
@@ -9192,7 +9192,7 @@ Notice that the four styles are designed to be used at the environment level: th
 
 The standard direction of currents, flows and voltages are changed by these options; notice that the default drops in case of passive and active elements is normally different. Take care that in the case of \texttt{noold} and \texttt{EFvoltages} also the currents can switch directions. It is much easier to understand the several behaviors by looking at the following examples, that have been generated by the code:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \foreach\element in {R, C, D, battery2, V, I,  sV, cV, cI}{%
     \noindent\ttfamily
     \begin{tabular}{p{2cm}}
@@ -9218,7 +9218,7 @@ The standard direction of currents, flows and voltages are changed by these opti
     }
     \par
 }
-\end{LTXexample}
+\end{ctikzExample}
 
 
 Obviously, you normally use just one between current and flows, but anyway you can
@@ -9233,21 +9233,21 @@ This manual has been typeset with the option \texttt{\chosenvoltoption}.
 
 Currents, voltages and flows (see later) are positioned along, or across, the part of the wires that connect the inner component to the rest of the circuit. So, changing the length of the connection (the coordinates that embrace the \texttt{to[...]} command) will change the position of the components.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (-1,1) to[R, v=$v$, i=$i$, f>^=$f$] (1,1);
     \draw (-2,0) to[R, v=$v$, i=$i$, f>^=$f$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 However, you can override the properties \IndexKey{voltage/distance from node} (default \texttt{0.5}: how distant from the initial and final points of the path the arrow starts and ends or the plus and minus symbols are drawn) and \IndexKey{voltage/bump b} (how high the bump of the arrow is --- how curved it is, default \texttt{1.5}), and also \IndexKey{voltage/european label distance} (how distant from the normal position the voltage label will be, default \texttt{1.4}) on a per-component basis, in order to fine-tune the voltages:
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw (0,0) to[R, v=1<\volt>] (2,0); \par
 \ctikzset{voltage/distance from node=.1}
 \ctikzset{voltage/bump b=2.5}
 \tikz \draw (0,0) to[R, v=1<\volt>] (2,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 You can also use a global \texttt{ctikzset} on the key \texttt{voltage/distance from node} (and similar) that will act as a default value. Notice however that the specific component value \textbf{overrides} the global one, and several components have pre-defined overrides, so they will ignore the default value. The components that have out of the box predefined overrides for \IndexKey[distance from node, override]{distance from node} are \texttt{generic}, \texttt{ageneric}, \texttt{fullgeneric} and \texttt{memristor} (set to \texttt{0.4}), and the ones that have it for \texttt{bump b} are
 \texttt{generic}, \texttt{ageneric}, \texttt{fullgeneric}, \texttt{memristor}, \texttt{tline}, \texttt{varistor}, \texttt{photoresistor}, \texttt{thermistor}, \texttt{thermistorntc}, \texttt{thermistorptc}, \texttt{ccapacitor}, \texttt{emptyzzdiode}, \texttt{fullzzdiode}, \texttt{emptythyristor}, \texttt{fullthyristor}, \texttt{emptytriac} and \texttt{fulltriac},, with several values (you can look at them in the file \texttt{pgfcirc.defines.tex}).\footnote{To achieve consistent results of \texttt{voltage/distance from node=0} refer to this solution by Jakob Leide on \href{https://tex.stackexchange.com/questions/757418/circuitikz-inconsistent-behaviour-of-voltage-distance-from-node}{tex.stackexchange.com}.}
@@ -9255,45 +9255,45 @@ You can also use a global \texttt{ctikzset} on the key \texttt{voltage/distance 
 
 Notice also that normally \texttt{distance from node} is a relative displacement, computed on the node-component wire. So that this will put the start and stop point $1/4$ of the way between node and component:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{voltage/distance from node=0.25}
     \draw (0, 2) to[D, v=$v_1$] ++(4,0);
     \draw (0, 1) to[D, v=$v_1$] ++(3,0);
     \draw (0, 0) to[D, v=$v_1$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The value of \texttt{distance from node} can also be an absolute distance; in that case is measured from the start of the connection toward the component on the left (and symmetrically on the right), so this will put the start and end point to \SI{0.25}{\cm} from the start of the node:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{voltage/distance from node=0.25cm}
     \draw (0, 2) to[D, v=$v_1$] ++(4,0);
     \draw (0, 1) to[D, v=$v_1$] ++(3,0);
     \draw (0, 0) to[D, v=$v_1$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 There is currently no way to specify the position at a fixed distance from the component (as opposed as from the node).
 
 The same concept as \texttt{distance from node} applies to the key \IndexKey{current/distance} for the position of the current's arrow (and to \IndexKey{flow/distance} for the flow arrow position):
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw (0,0) to[C, i=$\imath$] (2,0); \par
 \ctikzset{current/distance = .2}
 \tikz \draw (0,0) to[C, i=$\imath$] (2,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 If you want to change those parameters by defining a component-specific key you have to use the internal name of the component (in the component list, is the \texttt{nodename} without the terminal ``\texttt{shape}'' part):
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw (0,0) to[R, v=1<\volt>] (1.5,0)
        to[C, v=2<\volt>] (3,0); \par
 \ctikzset{bipoles/capacitor/voltage/distance from node/.initial=.7}
 \tikz \draw (0,0) to[R, v=1<\volt>] (1.5,0)
        to[C, v=2<\volt>] (3,0); \par
-\end{LTXexample}
+\end{ctikzExample}
 
 Note the \texttt{.initial}; you have to create such key the first time you use it. These kinds of adjustments are not guaranteed to work in future upgrades, though; if you have to create a key you are somehow touching the internal structure of the package; it's much safer to create a style.
 
@@ -9303,17 +9303,17 @@ One common request is to change the style of the arrows (both head and line) of 
 
 The ``active'' elements (sources and batteries, mainly) are treated differently from passive elements, in the sense that the default current and voltage direction and position could be different\footnote{This, in hindsight, has been a bad feature --- and I'm partly responsible for it. But removing it would create \emph{too small} variations in circuits, easily to go unnoticed, so it stays: nobody wants \emph{wrong} circuits just by recompiling.} following the chosen global voltage direction strategy (see section~\ref{curr-and-volt}). If they change or not depend on both the element and the chosen \texttt{voltage dir} option.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \draw (0,0) to[sV, v=$V_s$] ++(2,0)
         to[battery, v=$V_B$] ++(2,0)
         to[R, v=$V_R$] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 The consistency between symbols drawings and the default voltage and current directions are designed to work well \emph{when this default is enabled}. If you want, though, you can override this behavior by ``switching off'' the source status of the component by setting the property \IndexKey{bipole/is voltage} to \texttt{false}:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \draw (0,0) to[sV, bipole/is voltage=false,
             v=$V_s$] ++(2,0)
@@ -9321,20 +9321,20 @@ The consistency between symbols drawings and the default voltage and current dir
             v=$V_B$] ++(2,0)
         to[R, v=$V_R$] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 When you do this, \textbf{be careful} that (as you can see) the direction of the plain \texttt{v=...} option will change (please notice that this does not mean that it is incorrect, given that the voltage and current direction are arbitrary; in the case above, if the battery is a \SI{3}{V} one, $V_B=\SI{-3}{V}$ with the \texttt{RPvoltages} conventions).
 
 Also, notice that there is an ordering problem in the \texttt{to[...]} options: you have to switch the \texttt{is voltage} property off \textbf{before} setting the voltage, otherwise you will have a mix of the source-type and passive positioning:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     % correct way
     \draw (0,0) to[sV, bipole/is voltage=false, v=$V_s$] ++(2,0)
     % wrong way, setting voltage before changing type
         to[sV=$V_B$ , bipole/is voltage=false, ] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 In the first \texttt{to[]} command, the voltage is set before changing the type (assigning a value to the name of the element is understood as a \texttt{v=...} command for voltage sources).
 
@@ -9342,7 +9342,7 @@ A similar switch is present for current generators, called \IndexKey{bipoles/is 
 
 If you would prefer to switch to the \texttt{is voltage=false, is current=false} behavior by default, you can (since \texttt{v1.4.4}\footnote{Suggested by user \href{https://github.com/circuitikz/circuitikz/issues/590}{\texttt{@judober} on GitHub}.}) by setting the option \IndexKey{bipole/override source vif} to \texttt{true}. This is \emph{highly} experimental, so use with care.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[]
     \draw (0,0) to [battery=vb] ++(2,0)
         to[sV=sV] ++(2,0) to[R, v=vR] ++(2,0);
@@ -9350,11 +9350,11 @@ If you would prefer to switch to the \texttt{is voltage=false, is current=false}
     \draw (0,-2) to [battery=vb] ++(2,0)
         to[sV=sV] ++(2,0) to[R, v=vR] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that the option \texttt{override source vif} is ``stronger'' than the normal \texttt{is voltage}; so to locally re-set the behavior for just one source, you need to disable that \emph{before} using a voltage designator.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}[american]
     % dangerous option ahead: USE WITH CARE
     \ctikzset{bipole/override source vif=true}
@@ -9368,11 +9368,11 @@ Notice that the option \texttt{override source vif} is ``stronger'' than the nor
         bipole/is voltage=true,
         v=va] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Clearly, if you find yourself using the last component often, it is better to define a style, which will save you a lot of typing and help readability:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{myV/.style={V, bipole/override source vif=false,
     bipole/is voltage=true, v={#1}}}%
 \begin{tikzpicture}[american]
@@ -9381,7 +9381,7 @@ Clearly, if you find yourself using the last component often, it is better to de
     \draw (0,0) to [V>=va] ++(2,0);
     \draw (0,-2) to[myV=vb] ++(2,0);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 On the other way around, you could use styles to set \texttt{is voltage=false} only on the components you use and without using the global switch --- which is the recommended way of doing it.
 
@@ -9392,152 +9392,152 @@ Inline (along the wire) currents are selected with \IndexKey[i (current)]{}\verb
 Basically, \verb|^| and \verb|_| control if the label is above or below the line (above and below \textbf{do} depend on the direction of the component path), and \verb|<| and \verb|>| the direction of the arrow; swapping them (from for example from \verb|i^>| to \verb|i>^|) will switch the side of the component where the symbol is drawn. See the following examples:
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i^>=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i_>=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i^<=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i_<=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i>^=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i>_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i<^=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i<_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Also notice that the direction of the path is important:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (2,1) to[R, i<=$i_1$] (0,1);
    \draw (0,0) to[R, i<=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Default directions can change if the component is active or passive,\footnote{This is better explained in section~\ref{sec:source-vif}} following the chosen global voltage direction strategy (see section~\ref{curr-and-volt}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[V=10V, i_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[voltage dir=EF]
    \draw (0,0) to[V=10V, i_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \draw (0,0) to[V=10V, i_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \draw (0,0) to[V=10V,invert, i_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Current generators with the direct label (the one obtained by, for example, \texttt{I = something}) will treat it as a current:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[I=$a_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you use the option \IndexKey{americancurrent} or using the style \IndexKey{american currents}
 you can change the style of current generators.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american currents]
    \draw (0,0) to[I=$a_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Flows}\label{flows}
 
 As an alternative for the current arrows, you can also use the following ``flows\IndexKey[f (flow, current)]{}''. They can also be used to indicate thermal or power flows. The syntax is pretty the same as for currents.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f<=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f_>=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f<^=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f<_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, f>_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Voltages}
 \label{sec:voltages}
@@ -9550,183 +9550,183 @@ Direction and position of the symbols are controlled in the same way as for the 
 \subsubsection{European style} The default, with curved arrows. Use option \IndexKey{europeanvoltage} or style \IndexKey{european voltages}, or setting (even locally) \IndexKey[voltage, european]{voltage=european}.
 \label{sec:european-style}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european voltages]
    \draw (0,0) to[R, v^>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european voltages]
    \draw (0,0) to[R, v^<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european voltages]
    \draw (0,0) to[R, v_>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european voltages]
    \draw (0,0) to[R, v_<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The default direction for active elements can change, depending on the global \texttt{voltage dir} setting, so be careful.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[I=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[I<=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[I=$~$,l=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[I,l=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Moreover, for historical reasons, voltage generators have differently looking arrows (they are straight even in curved European style).
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[V=10V, i_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can change this last thing by forcing ``off'' the status of ``voltage generator''  of the component; but now the normal (passive) rule will apply, so, again, be careful and read section~\ref{sec:source-vif}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[battery, bipole/is voltage=false,
                  v>=$u_1$,] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As for the currents, the direct label of voltage sources is passed as a voltage:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[cV=$k\cdot a_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The following results from using the option \IndexKey{americanvoltage} or the style \IndexKey{american voltages}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
    \draw (0,0) to[V=$a_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Straight European style} Using straight arrows. Use option \IndexKey{straightvoltages} or style \IndexKey{straight voltages}, or setting (even locally) \IndexKey[voltage, straight]{voltage=straight}.
 \label{sec:straight-european-style}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[R, v^>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[R, v^<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[R, v_>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[R, v_<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Again, voltage generators are treated differently:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[V=10V, i_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[I, v=10V, i_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 And you can override that with \texttt{bipole/is voltage} keeping into account that the default direction will be the one of passive components (see~\ref{sec:source-vif}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages]
    \draw (0,0) to[V, bipole/is voltage=false,
         v=10V, i_=$i_1$] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{American style}
 \label{sec:american-style}
 Use option \IndexKey{americanvoltage} or set \IndexKey{american voltages} or use the option \IndexKey[voltage, american]{voltage=american}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
    \draw (0,0) to[R, v^>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
    \draw (0,0) to[R, v^<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
    \draw (0,0) to[R, v_>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
    \draw (0,0) to[R, v_<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \draw (0,0) to[I=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \draw (0,0) to[I<=1A, v_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Raised American style}
@@ -9736,48 +9736,48 @@ Since version \texttt{1.2.1}, ``raised'' American voltages are available; to use
 This is a version of the American-style voltage where the signs are raised to the level of the label.
 The label is centered between the two signs, and the position of the signs is calculated by supposing that the label itself will be pretty simple; if you have very big labels you will need to adjust the position with \IndexKey{voltage shift} and/or the \IndexKey{voltage/distance from node} properties (see section~\ref{sec:common-vif-pos}).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,0) to[R, v^>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,0) to[R, v^<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,0) to[R, v_>=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,0) to[R, v_<=$v_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
    \ctikzset{voltage=raised}
    \draw (0,0) to[I=1A, v_=$u_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,0) to[I<=1A, v_=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Voltage position}\label{sec:sub-voltage-position}
 
 It is possible to move the arrows and the plus or minus signs away from the component with the key \IndexKey{voltages shift} (default value is \texttt{0}, which gives the standard position):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
    \draw (0,0) to[R, v=$v_1$, i=$i_1$] (2,0);
    \draw (0,-1) to[R, v=$v_1$, i=$i_1$,
@@ -9785,27 +9785,27 @@ It is possible to move the arrows and the plus or minus signs away from the comp
    \draw (0,-2) to[R, v=$v_1$, i=$i_1$,
       voltage shift=1.0] (2,-2);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages, voltage shift=0.5]
    \draw (0,0) to[R, v=$v_1$, i=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Negative values do work as expected:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[raised voltages]
    \draw (0,1.5) to[R, v^=$v_1$, i=$i_1$] ++(2,0);
    \draw (0,0) to[R, v^=$v_1$, i_=$i_1$,
         voltage shift=-1.0] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Unfortunately\footnote{see \href{https://github.com/circuitikz/circuitikz/issues/747}{this bug report}.} the amount of shift given by \texttt{voltage shift} is not always the same between sources and passive bipoles, especially if the sizes of the component is very different from the default. Although this qualifies as a bug, and should be fixed in a more comprehensive way, a workaround is available with the key \IndexKey{voltage shift sources adjust} (default: \texttt{\ctikzvalof{voltage shift sources adjust}}). A smaller value is better for smaller components, as you can see in the example below.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \newcommand{\example}[2][]{\draw[#1] (#2)
         to [V_=$U$] ++(0, -1) (#2) ++(2,0)
         to [R,v=$U_R$] ++(0,-1);
@@ -9820,36 +9820,36 @@ Unfortunately\footnote{see \href{https://github.com/circuitikz/circuitikz/issues
     \ctikzset{voltage shift sources adjust=0.2}
     \example[color=blue]{0,0}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can fine-tune the position of the \texttt{+} and \texttt{-} symbols and the label in independent way using \IndexKey{voltage/shift} (default \texttt{0.0} for the former and \IndexKey{voltage/american label distance} (the distance of the label from the lines of the symbols, default \texttt{1.4}) for the latter.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
     \draw (0,1) to[R, v=$v_1$, i=$i_1$] ++(2,0);
     % normally 1.4, make it tighter
     \ctikzset{voltage/american label distance=0.5}
     \draw (0,0) to[R, v=$v_1$, i=$i_1$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notes that \texttt{american voltage} also affects batteries.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[voltage shift=0.5]
    \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages, voltage shift=0.5]
    \draw (0,0) to[battery,l_=1V, v=$u_1$, i=$i_1$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Additionally, the \IndexKey{open} component is treated differently; the voltage is placed in the middle of the open space\footnote{Since \texttt{v1.1.2}, thank to an \href{https://github.com/circuitikz/circuitikz/issues/374}{issue opened by user \texttt{rhandley} on GitHub}.}:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american voltages]
     \draw (0,1.5) -- ++(0.5,0)
         to[open, v=$v_o$, o-o] ++(2,0) -- ++(0.5,0);
@@ -9857,7 +9857,7 @@ Additionally, the \IndexKey{open} component is treated differently; the voltage 
         to[open, v=$v_o$, voltage=straight, *-*] ++(2,0)
         -- ++(0.5,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you want or need to maintain the old behavior for \texttt{open} voltage, you can set the key \IndexKey{open voltage position} to \texttt{legacy} (the default is the new behavior, which corresponds to the value \texttt{center}).
 
@@ -9865,7 +9865,7 @@ If you want or need to maintain the old behavior for \texttt{open} voltage, you 
 
 Since 0.9.0, you can change the font\footnote{There was a bug before, noticed by the user \texttt{dzereb} on \href{https://tex.stackexchange.com/questions/487683/odd-minus-style-when-drawing-american-voltage}{tex.stackexchange.com} which made the symbols using different fonts in a basically random way. In the same page, user \texttt{campa} found the problem. Thanks!} used by the \texttt{american voltages} style, by setting to something different from nothing the key \IndexKey{voltage/american font} (default: nothing, using the current font) style:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \begin{scope}
         \ctikzset{voltage/american font=\tiny\boldmath}
@@ -9873,14 +9873,14 @@ Since 0.9.0, you can change the font\footnote{There was a bug before, noticed by
     \end{scope}
     \draw (0,-2) to[R,v=$V_S$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Also, if you want to change the symbols (sometimes just the $+$ sign is drawn, for example, or for highlighting something),
 using the keys \IndexKey{voltage/american plus} and \IndexKey{voltage/american minus} (default \verb|$+$| and \verb|$\vphantom{+}-$|).
 
 Notice that the definition of the minus sign is not simply \verb|$-$| because in most font (but not Computer Modern!) the size of the bounding box for the mathematical plus or minus are different. The \verb|\vphantom| forces the vertical size of the minus sign to be the same as the plus sign.\footnote{Changed in v1.6.3, you can look at \href{https://github.com/circuitikz/circuitikz/issues/721}{this issue on GitHub} for more details.}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \ctikzset{voltage/american font=\scriptsize\boldmath}
     \ctikzset{voltage/american plus=\textcolor{red}{$\oplus$}}
@@ -9888,11 +9888,11 @@ Notice that the definition of the minus sign is not simply \verb|$-$| because in
     \draw (0,0) to[R,v_>=$V_S$] ++(2,0);
     \draw (0,-2) to[R,v_<=$V_S$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This could be especially useful if you define a style, to use like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{red plus/.style={
     circuitikz/voltage/american plus=\textcolor{red}{$+$},
 }}
@@ -9900,14 +9900,14 @@ This could be especially useful if you define a style, to use like this:
     \draw (0,0) to[R,v_>=$V_S$, red plus] ++(2,0);
     \draw (0,-2) to[R,v_<=$V_S$] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Combining different styles}\label{sec:mixing-voltage-styles}
 
 Due to an historical hiccup, you need to be careful if you want to mix styles, like for example having \texttt{american} styled components and straight voltages (which are basically \texttt{european} style, at least in \Circuitikz{}). The problem is that the order of style parameters can change the output\footnote{%
 thanks to Stack Exchange user \href{https://tex.stackexchange.com/q/665466/38080}{Mads P Olesen} for noticing.} as you can see in the following example, where in the red case the voltage generator shape reverted to the \texttt{european} one.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[straight voltages, american]
     \draw (0,0) to [V, v=$V_P$] ++(0,3);
     \draw (1,0) to [R, v=$V_P$] ++(0,3);
@@ -9916,7 +9916,7 @@ thanks to Stack Exchange user \href{https://tex.stackexchange.com/q/665466/38080
     \draw (0,0) to [V, v=$V_P$] ++(0,3);
     \draw (1,0) to [R, v=$V_P$] ++(0,3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 This is arguably a bug, but fixing it (separating the voltage generator shapes from the voltage style) would break havoc with older circuits, so this will not be fixed for now.
 
@@ -9950,7 +9950,7 @@ where the annotation will be in normal font (it has been reset!) and red, or app
 The available styles and commands are \IndexKey{bipole label style}, \IndexKey{bipole annotation style}, \IndexKey{bipole voltage style}, \IndexKey{bipole current style}, and \IndexKey{bipole flow style}. The following example shows a bit of everything.
 
 
-\begin{LTXexample}[pos=t ]
+\begin{ctikzExample}[pos=t ]
 \begin{circuitikz}[american]
     \ctikzset{bipole annotation style/.style={font=\tiny}}
     \ctikzset{bipole current style/.style={font=\small\sffamily}}
@@ -9961,14 +9961,14 @@ The available styles and commands are \IndexKey{bipole label style}, \IndexKey{b
         R=R1, v=V1, i=I1, f>^=F1] ++(3,0)
     to [bipole current append style={color=red}, R, v<=V2, i^=I2, f>^=F2] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Accessing labels text nodes}
 \label{sec:accessing-labels-text}
 
 Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{label}s and \texttt{annotation}s was present before, but not documented.} using special node names. So, if you use \texttt{name} to give a name to the bipole node, you can also access the following nodes: \texttt{namelabel} (notice: no space nor any other symbol between \texttt{name} and \texttt{label}!), \texttt{nameannotation}, \texttt{namevoltage}, \texttt{namecurrent} and \texttt{nameflow}. Notice that the node names are available only if the bipole has an anchor or an annotation, of course.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \newcommand{\marknode}[2][45]{%
     \node[circle, draw, red, inner sep=1pt,
     pin={[red, font=\tiny]#1:#2}] at (#2.center) {};
@@ -9984,14 +9984,14 @@ Since 0.9.5, you can access all the labels nodes\footnote{The access to \texttt{
     \marknode[0]{R1voltage} \marknode[0]{R2voltage} \marknode[90]{R1current}
     \marknode[90]{R2current} \marknode{R1flow} \marknode{R2flow}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 If you want to have more access to the label positioning algorithm, since \texttt{1.2.5} you can access the label  rotation using the command \ \IndexKey[ctikzgetdirection]{}\texttt{\textbackslash ctikzgetdirection\{\emph{nodename}\}} (where node name is for example \texttt{L1label} or \texttt{L2annotation}), and the anchor used for positioning the node as \texttt{\textbackslash ctikzgetanchor\{\emph{component label}\}\{\emph{type}\}}, where \emph{component label} is, for example, \texttt{L1} and type is either \texttt{label} or \texttt{annotation} (notice that the syntax is slightly different, for implementation reasons).
 Those values are available only if the dipole declares a \texttt{l} or \texttt{a} keys; if you want them without any label you need to declare a blank one (like for example \texttt{l=\textasciitilde}).
 The following example gives an idea of the values of those macros for the three types of label positioning strategies.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \newcommand{\marklabann}[3][45]{% [angle] {node label} {type: label or annotation}
 \node[circle, draw, blue, inner sep=1pt,
 pin={[draw, blue, font=\tiny, align=left]#1:{#2 \\ dir: \ctikzgetdirection{#2#3} \\
@@ -10009,7 +10009,7 @@ pin={[draw, blue, font=\tiny, align=left]#1:{#2 \\ dir: \ctikzgetdirection{#2#3}
         \marklabann[-90]{V1}{annotation}
 \end{scope}}
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Advanced voltages, currents and flows}\label{sec:vif-anchors}
 
@@ -10018,7 +10018,7 @@ Normally, voltages and flow and currents are drawn into the path of the bipoles,
 
 For example, you can do something like this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,1) to[R, v=$v$] ++(3,0);
     \draw (0,0) to[R, v, name=R, voltage/bump b=3] ++(3,0);
@@ -10026,11 +10026,11 @@ For example, you can do something like this:
     (R-Vfrom) .. controls (R-Vcont1) and (R-Vcont2).. (R-Vto)
     node [black, pos=0.5, fill=white]{v};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Or, for example, to have a different voltage style; normally you would define a macro (see~\ref{sec:american-voltage-custom} to understand the \verb|\vphantom|).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[voltage shift=0.5]
     \def\eurVPM#1#2{% node, label
         \draw [thin, -{Stealth[width=8pt]}, shorten >=5pt,
@@ -10042,13 +10042,13 @@ Or, for example, to have a different voltage style; normally you would define a 
         to[R, l_=R2, v^, name=R2] ++(0,-3);
     \eurVPM{R1}{$v_1$} \eurVPM{R2}{$v_2$}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Using standard label with custom symbols}\label{sec:no-symbols}
 
 Since \texttt{v1.4.1} you can also keep the voltage, current and flow labels and suppress the output of the symbols (arrows or plus/minus depending on the style) with the keys \IndexKey{no v symbols}, \IndexKey{no i symbols}, \IndexKey{no f symbols} (there are also the corresponding \IndexKey{v symbols}, \IndexKey{i symbols} and \IndexKey{f symbols} in case you want to switch the behavior off/on  globally). This for example simplify an often requested feature, like having all the current in one color and the voltages in another one, which is not possible natively because the arrows are part of the same path. One possible implementation of that is the following one:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \newcommand{\iarronly}[1]{% name
     \node [currarrow, color=red, anchor=center,
     rotate=\ctikzgetdirection{#1-Iarrow}] at (#1-Ipos) {};
@@ -10068,7 +10068,7 @@ Since \texttt{v1.4.1} you can also keep the voltage, current and flow labels and
         (180:2) to[V, -*, name=V2, v_=$v_2$, !vi] (0:0);
     \iarronly{SR}\varronly{R}\varronly{L2}\varronly{V2}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Activating the anchors}
 \label{sec:activating-the-anchors}
@@ -10200,7 +10200,7 @@ When the anchors are activated, there are additional macros that you can use:
 
 For example, you could like the voltage label oriented with the bipole:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \def\myvv#1#2{%
     \draw [thin, blue, ->,]
@@ -10211,22 +10211,22 @@ For example, you could like the voltage label oriented with the bipole:
     \draw (0,0) to[R, v, name=B] ++(3,3);
     \myvv{A}{$v_A$}\myvv{B}{$v_B$}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Or you could use the anchor to substitute the flow with a fancy one and still position the label automatically; suppose you have the following definition in your preamble (see \TikZ{} manual, ``Path decorations''):
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 % requires \usetikzlibrary{decorations, decorations.pathmorphing}
 \tikzset{%
 lray/.style={decorate, decoration={
     snake, amplitude=2pt,pre length=1pt,post length=2pt, segment length=5pt,},
     -Triangle,
 }}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can then define a kind of ``power flow'' style:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \newcommand\myff[3][blue]{% [opt: color] node label
         \draw [lray, #1, ] (#2-Ffrom) -- (#2-Fto)
@@ -10236,7 +10236,7 @@ You can then define a kind of ``power flow'' style:
     \draw (0,0) to[R, f_<, name=B] ++(3,0);
     \myff{A}{$P_A$}\myff[red]{B}{$P_B$}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 
@@ -10247,17 +10247,17 @@ You can then define a kind of ``power flow'' style:
 An interesting application of the advanced voltage is to have fixed length straight voltage arrows.\footnote{This was suggested by users  \texttt{Franklin} and \texttt{Zarko} in \href{https://tex.stackexchange.com/questions/574576/circuitikz-straight-voltage-arrows-with-fixed-length}{a question on \texttt{tex.stackexchange.com}}}
 The normal voltage arrows length depends not on the component length but on the node distance (this is the behavior since when the voltages were first introduced, so it can't be changed).
 
-\begin{LTXexample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
+\begin{ctikzExample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
 \begin{circuitikz}[european,]
     \ctikzset{voltage=straight}
     \draw (0,0) to[R,v=$v_1$,*-*] ++(2,0) to[R, v<=$v_2$] ++(4,0) to[C, *-*, v=$v_3$] ++(1,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Using the advanced voltage interface mechanism, you can for example design voltages that are of fixed lengths; in the example below the new \texttt{xparse} method for defining commands is used, so that we can have a couple of different optional arguments:
 
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily, exec outside]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily, exec outside]
 \NewDocumentCommand{\fixedvlen}{O{0.5cm} m m O{}}{% [semilength]{node}{label}[extra options]
     % get the center of the standard arrow
     \coordinate (#2-Vcenter) at ($(#2-Vfrom)!0.5!(#2-Vto)$);
@@ -10266,9 +10266,9 @@ Using the advanced voltage interface mechanism, you can for example design volta
     % position the label as in the normal voltages (inner sep of voltage labels is 2pt per default)
     \node[anchor=\ctikzgetanchor{#2}{Vlab}, inner sep=2pt, #4] at (#2-Vlab) {#3};
 }
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
+\begin{ctikzExample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
 \begin{circuitikz}[european,]
     \ctikzset{voltage=straight}
     \draw (0,2) to[R,v=$v_1$,*-*] ++(2,0) to[R, v<=$v_2$] ++(4,0) to[C, *-*, v=$v_3$] ++(1,0);
@@ -10277,7 +10277,7 @@ Using the advanced voltage interface mechanism, you can for example design volta
     \fixedvlen{v2}{$V_2$}
     \fixedvlen{v3}{$V_3$}[red]
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that with a coherent naming you can use a \verb|\foreach| loop for the last three lines.
 
@@ -10285,7 +10285,7 @@ You can also notice that the arrow is not exactly the same as other arrows in th
 
 Another possibility is to have the arrow length based on the length of the component; for example you can use this code:
 
-\begin{LTXexample}[basicstyle=\scriptsize\ttfamily, exec outside]
+\begin{ctikzExample}[basicstyle=\scriptsize\ttfamily, exec outside]
 \NewDocumentCommand{\compvlen}{O{1.5} m m O{}}{% [relative length]{node}{label}[extra options]
     % get the center of the standard arrow
     \coordinate (#2-Vcenter) at ($(#2-Vfrom)!0.5!(#2-Vto)$);
@@ -10298,9 +10298,9 @@ Another possibility is to have the arrow length based on the length of the compo
     % position the label as in the normal voltages
     \node[anchor=\ctikzgetanchor{#2}{Vlab}, #4] at (#2-Vlab) {#3};
 }
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
+\begin{ctikzExample}[varwidth=true, basicstyle=\scriptsize\ttfamily, pos=t]
 \begin{circuitikz}[european,]
     \ctikzset{voltage=straight}
     \draw (0,2) to[R,v=$v_1$,*-*] ++(2,0) to[R, v<=$v_2$] ++(4,0) to[C, *-*, v=$v_3$] ++(1,0);
@@ -10309,7 +10309,7 @@ Another possibility is to have the arrow length based on the length of the compo
     \compvlen{v2}{$V_2$}
     \compvlen{v3}{$V_3$}[red]
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \endgroup
 
@@ -10356,7 +10356,7 @@ For example, let's suppose you like the \texttt{raised} voltage notation, but yo
 
 % TODO: Move this in the listing as well?
 \ctikzset{voltage=raised, !v sym/.style={no v symbols}}
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 %% The voltage label (the text) will be managed normally by v...={}
 %% We need just one parameter to specify the coloa/styler of the signs; we
 %% set the other argument to nothing.
@@ -10370,9 +10370,9 @@ For example, let's suppose you like the \texttt{raised} voltage notation, but yo
     \path ($(#1voltage.center)!0.5cm!(#1-Vto)$) node[#2]{$+$};
     \path ($(#1voltage.center)!0.5cm!(#1-Vfrom)$) node[#2]{$-$};
 }
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (3,0) -- ++(1,0) coordinate(Rbot)
         to[R=R, name=vR, v={$u_R$}, my v={red}]
@@ -10383,7 +10383,7 @@ For example, let's suppose you like the \texttt{raised} voltage notation, but yo
         \draw (Cbot) to [L=L, v_>={$u_L$},
         my v={white,fill=black}] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you have an old \LaTeX{} or are using \ConTeXt, you must add the \texttt{use auto vif} to the options of the environment; the option will not have any negative effect if it is not needed.
 
@@ -10395,7 +10395,7 @@ If you have an old \LaTeX{} or are using \ConTeXt, you must add the \texttt{use 
 
 Suppose now we want to change the current indication so that we can typeset the label using \verb!\boldmath!, changing the style of the label and the color of the arrow. For example, we could define the following:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 %% arguments: label, style for the arrow, style for the label
 \ctikzset{my i/.style n args  = {3}{vif queue add={docurrent}{#1}{#2}{#3}}}
 \newcommand{\docurrent}[4]{
@@ -10404,9 +10404,9 @@ Suppose now we want to change the current indication so that we can typeset the 
     \node [anchor=\ctikzgetanchor{#1}{Ilab}, outer sep=4pt, inner sep=1pt,
     #4] at (#1-Ipos) {{\boldmath #2}}; %the double {} are needed!!!
 }
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     % set a default for my v
     \ctikzset{my v/.default=blue}
@@ -10421,7 +10421,7 @@ Suppose now we want to change the current indication so that we can typeset the 
         my i={\rotatebox{90}{$i=0$}}{green}{fill=yellow}]
         ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsubsection{Creating new voltage/current/flows commands}\label{sec:activate-directions}
@@ -10429,7 +10429,7 @@ Suppose now we want to change the current indication so that we can typeset the 
 Sometimes, the need of using the syntax \texttt{v, my v=\dots} can result tedious; unfortunately, it is not possible to add the \texttt{v} to the key \texttt{my v} because it will reset the direction/position of the key. To avoid this problem, you can use the new command
 \verb!\!\IndexKey{ctikzactivatevoltagedirections} (and their sibling \verb!\!\IndexKey{ctikzactivatecurrentdirections} and \verb!\!\IndexKey{ctikzactivateflowdirections}) which will create the full set of personalized voltage (or current or flow) commands with the appended directions. For example, this is how we can reimplement the ``European arrow with signs'' shown in the previous section:
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \newcommand\eurVPM[4]{% node, label, two ignored arguments
     \draw [thin, -{Stealth[width=4pt]}, shorten >=5pt, shorten <=5pt]
     (#1-Vfrom) node[font=\tiny]{$\vphantom{+}-$}
@@ -10440,19 +10440,19 @@ Sometimes, the need of using the syntax \texttt{v, my v=\dots} can result tediou
 \ctikzset{vpm/.style={european voltages, v, vif queue add={eurVPM}{#1}{}{}}}
 % do magic with vpm
 \ctikzactivatevoltagedirections{vpm}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[voltage shift=0.5]
     \draw (0,0)
         to[R=R1, name=R1, i=$i$, vpm=$v_1$] ++(4,0)
         to[R, l_=R2, vpm^>=$v_2$] ++(0,-3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can use this trick even with styles with more than one argument, but then you have to be sure to always add both argument \emph{braced}, otherwise very strange errors will be generated.
 
-\begin{LTXexample}[exec outside]
+\begin{ctikzExample}[exec outside]
 \newcommand\eurVPMstyled[4]{% node, label, arrow style, one ignored arguments
     \draw [thin, -{Stealth[width=4pt]}, shorten >=5pt, shorten <=5pt, #3]
     (#1-Vfrom) node[font=\tiny]{$\vphantom{+}-$}
@@ -10463,16 +10463,16 @@ You can use this trick even with styles with more than one argument, but then yo
 \ctikzset{vpms/.style 2 args={european voltages, v,
     vif queue add={eurVPMstyled}{#1}{#2}{}}}
 \ctikzactivatevoltagedirections{vpms}%
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[voltage shift=0.5]
     \draw (0,0)
         to[R=R1, name=R1, i=$i$, vpms={$v_1$}{dashed}]
         ++(4,0)
         to[R, l_=R2, vpms^>={$v_2$}{blue}] ++(0,-3);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \endgroup % close automatic-vif
 
@@ -10483,41 +10483,41 @@ You can see a full example at~\ref{sec:example-auto-vif}.
 
 If the option {\ttfamily siunitx} is active\footnote{This option is still experimental --- personally (Romano) I would advise using the normal \texttt{\textbackslash SI\{\}\{\}} syntax, or the \texttt{\textbackslash qty\{\}\{\}} one for \IndexKey{siunitx} \texttt{v3} and newer.}, then the following are equivalent (this will \textbf{not} work in \ConTeXt{}, it has been disabled in upstream \ConTeXt, in favor of \href{https://www.pragma-ade.nl/general/manuals/units-mkiv.pdf}{its own \texttt{units} module}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, l=1<\kilo\ohm>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, l=$\SI{1}{\kilo\ohm}$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i=1<\milli\ampere>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, i=$\SI{1}{\milli\ampere}$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, v=1<\volt>] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, v=$\SI{1}{\volt}$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \section{Using bipoles in circuits}
@@ -10527,126 +10527,126 @@ If the option {\ttfamily siunitx} is active\footnote{This option is still experi
 You can add nodes to the bipoles, positioned at the coordinates surrounding the component. The general style to use is \IndexKey[bipole nodes]{bipole nodes=\{start\}\{stop\}}, where \texttt{start} and \texttt{stop} are the nodes --- to be chosen between \texttt{none}, \texttt{circ}, \texttt{ocirc}, \texttt{squarepole}, \texttt{osquarepole}, \texttt{diamondpole},  \texttt{odiamondpole} and \texttt{rectfill}\footnote{You can use other shapes too, but at your own risk\dots Moreover, notice that \texttt{none} is not really a node, just a special word used to say ``do not put any node here''.} (see section~\ref{sec:terminals}).
 
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{bipoles/length=.5cm, nodes width=0.1}%small components, big nodes
     \foreach \a/\p [evaluate=\a as \b using (\a+180)] in
     {-90/none, -60/circ, -30/ocirc, 0/diamondpole, 30/odiamondpole, 60/squarepole, 90/osquarepole}
         \draw (0,0) to[R, bipole nodes={none}{\p}] ++(\a:1.5)  node[font=\tiny, anchor=\b]{\p};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 These bipole nodes are added \emph{after} any single path is drawn, as every node in \TikZ\ --- this is the reason why they are always filled (with the main color the normal nodes, with white the open ones), in order to ``hide'' the wire below. You can override the fill color if you want; but notice that if you draw things in two different paths, you will have ``strange'' results; notice that in the second line of resistors the second wire is starting from the center of the white \texttt{ocirc} of the previous path.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
     \draw (0,0) to[R, *-o] ++(2,0) to[R, -d] ++(2,0)
         to[R, bipole nodes={diamondpole}{odiamondpole, fill=red}] ++(2,0);
     \draw (0,-1) to[R, *-o] ++(2,0) ;
     \draw (2,-1) to[R, -d] ++(2,0) to[R, bipole nodes={none}{squarepole}] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can define shortcuts for the \texttt{bipole nodes} you use most; for example if you want a shortcut for a bipole with open square node in red in the right side you can:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{-s/.style = {bipole nodes={none}{osquarepole, fill=red}}}
     \draw (0,0) to[R, -s] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 There are several predefined shorthand as the above; in the following pages you can see all of them.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, o-o] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, -o] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, o-] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, *-*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, -*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, *-] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, d-d] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, -d] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, d-] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, o-*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, *-o] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, o-d] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, d-o] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, *-d] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R, d-*] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Transparent poles}\label{sec:transparent-poles}
 
@@ -10656,7 +10656,7 @@ Anyway, \emph{if you know what you are doing}, you can change it with the key \I
 
 Notice that in poles, the opacity is \emph{always} selected with these keys, and it overrides the opacity of the draw commands (when not set explicitly is as if it is set to \texttt{1.0}, i.e., full opaque). This is because you normally do not want unfilled poles!
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \begin{circuitikz}[scale=3, transform shape]
     \fill[cyan] (0,0) rectangle (4.1,-0.6);
     \ctikzset{open poles fill=red}
@@ -10673,7 +10673,7 @@ Notice that in poles, the opacity is \emph{always} selected with these keys, and
     % notice that in node commands you can specify the opacity directly
     \draw (3.6,0) -- ++(0.2,0) node[ocirc, fill=white, fill opacity=0.5, anchor=180]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You also have the similar keys for the ``full'' poles (albeit they are probably not useful at all).
 
@@ -10682,83 +10682,83 @@ You also have the similar keys for the ``full'' poles (albeit they are probably 
 \label{sec:mirroring-and-inverting}
 Bipole paths can also be mirrored and inverted (or reverted) to change the drawing direction.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[pD] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[pD, mirror] (2,0);
 \end{circuitikz}
-\end{LTXexample}
-\begin{LTXexample}
+\end{ctikzExample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[pD, invert] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Placing labels, currents and voltages also works, please note, that mirroring and inverting does not influence the positioning of labels and voltages. Labels are by default above/right of the bipole and voltages below/left, respectively.
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[ospst=T, i=$i_1$, v=$v$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[ospst=T, mirror, i=$i_1$, v=$v$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[ospst=T, invert, i=$i_1$, v=$v$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
-\begin{LTXexample}
+\end{ctikzExample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[ospst=T,mirror,invert, i=$i_1$, v=$v$] (2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \subsection{Putting them together}
 \label{sec:putting-them-together}
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[R=1<\kilo\ohm>,
       i>_=1<\milli\ampere>, o-*] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
    \draw (0,0) to[D*, v=$v_D$,
       i=1<\milli\ampere>, o-*] (3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Line joins between Path Components}
 \label{sec:line-joins}
 
 Line joins should be calculated correctly - if they are on the same path, and the path is not closed. For example, the following path is not closed correctly (\texttt{--cycle} does not work here!):
-\begin{LTXexample}
+\begin{ctikzExample}
 	\begin{tikzpicture}[line width=3pt,european]
 	\draw (0,0) to[R]++(2,0)to[R]++(0,2)
 		--++(-2,0)to[R]++(0,-2);
 	\draw[red,line width=1pt] circle(2mm);
 	\end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 To correct the line ending, there are support shapes to fill the missing rectangle. They can be used like the support shapes (*,o,d) using a dot (.) on one or both ends of a component (have a look at the last resistor in this example:
-\begin{LTXexample}
+\begin{ctikzExample}
 	\begin{tikzpicture}[line width=3pt,european]
 	\draw (0,0) to[R]++(2,0)to[R]++(0,2)
 		--++(-2,0)to[R,-.]++(0,-2);
 	\draw[red,line width=1pt] circle(2mm);
 	\end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \section{Colors}\label{sec:colors}
 
@@ -10766,10 +10766,10 @@ Color support in \Circuitikz{} has been quite limited up to version 1.5.1; from 
 
 Part of the problem is how colors in paths are treated by \TikZ{} itself; you can see part of the discussion on \href{https://github.com/circuitikz/circuitikz/issues/605}{this issue} and in \href{https://tex.stackexchange.com/questions/634987/pgf-basic-layer-struggling-again-with-colors}{this question on TeX.SX} --- many thanks to \texttt{@muzimuzhi} for helping there. Basically, nodes are drawn \emph{after} the path is completed, and color is applied to the path at the end. Look at this code (pure \TikZ, no \Circuitikz{} here):
 
-\begin{LTXexample}[varwidth=true]
+\begin{ctikzExample}[varwidth=true]
 \tikz \draw[thick] (0,0) -- (1,0) {[color=red] -- (2,0) node[draw]{}} --(3,0); \par
 \tikz \draw[thick] (0,0) -- (1,0) [color=red] -- (2,0) node[draw]{} --(3,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 So the path is drawn with the last ``effective'' (in current group) color. The deferred behavior of the color properties is very difficult to track for \Circuitikz, especially when the shorthand \IndexKey[color]{color-name} (e.g., \texttt{red} instead of \texttt{color=red}) is used. \Circuitikz{} will try to keep track of the colors specified by \texttt{color=...} and \texttt{fill=...}, but if you use the implicit way (\texttt{\textbackslash draw[red]...}) it often fails.
 
@@ -10782,7 +10782,7 @@ after loading \Circuitikz, and it will try to patch the default commands to keep
 Before 1.5.0, \Circuitikz{} used black as the default color. Now it tries to follow the current color, as \TikZ{} does normally; but notice that there is a difference with the fill strategy:
 
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \color{red}
 Red text
 \tikz \draw (0,0) -- node[draw] {x} (1,0) -- node[draw=cyan] {y} (2,0);
@@ -10797,7 +10797,7 @@ Blue text
 Black text
 \tikz \draw[fill=yellow] (0,0) -- node[draw, fill] {x} (1,0) -- node[draw=cyan] {y} (2,0);
 \tikz \draw[fill=yellow] (0,0) to[R] (2,0) to[R,color=cyan] (4,0) to [generic] (6,0) to [fullgeneric] (8,0);
-\end{LTXexample}
+\end{ctikzExample}
 
 \Circuitikz{} components that are fillable will inherit the \IndexKey[fill (color)]{fill} property of the path (it is almost impossible to do otherwise) as if the \texttt{fill} flag was present. ``Full''-type elements (for example, full diodes or similar) are filled with the draw color; elements with intrinsic labels (i.e., labels that are part of the shape, like signs on amplifiers and pin numbers in chips) are drawn with the ``draw'' colors.
 
@@ -10818,7 +10818,7 @@ Moreover, in some cases, also the engine you are using (as \texttt{pdflatex}, \t
 
 The color of the components is stored in the key \verb!\circuitikzbasekey/color!. Circui\TikZ\ tries to follow the color set in \TikZ, although sometimes it fails. The following circuit will fail to draw the circuit in red if the patching of the inner commands of \TikZ{} fails, like for example in \ConTeXt{}.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw[red]
   (0,2) node[and port](myand1){1}
   (0,0) node[and port](myand2){2}
@@ -10826,11 +10826,11 @@ The color of the components is stored in the key \verb!\circuitikzbasekey/color!
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you see this problem, please do not use just the color name as a style, like \verb![red]!, but rather assign the style \verb![color=red]!.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw[color=red]
   (0,2) node[and port](myand1){1}
   (0,0) node[and port](myand2){2}
@@ -10838,10 +10838,10 @@ If you see this problem, please do not use just the color name as a style, like 
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 One can, of course, change the color directly in the component:
-\begin{LTXexample}[pos=t, varwidth=true]
+\begin{ctikzExample}[pos=t, varwidth=true]
 \begin{circuitikz} \draw
   (0,0) node[pnp, color=blue](pnp2){q1}
   (pnp2.B) node[pnp, xscale=-1, anchor=B, color=brown](pnp1){\ctikzflipx{q2}}
@@ -10850,54 +10850,54 @@ One can, of course, change the color directly in the component:
   (pnp1.E) -- (pnp2.E)  (npn1.E) -- (npn2.E)
   (pnp1.B) node[circ]{} |- (pnp2.C) node[circ]{}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The all-in-one stream of bipoles poses some challenges, as only the actual body of the bipole, and not the connecting lines, will be rendered in the specified color (Notice that the following example uses the special \texttt{siunitx} shorthand; you can use it only in simple cases like here, in general using the full \verb|\SI{}| or \verb|\qty{}| commands).
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[V=1<\volt>] (0,2)
         to[R=1<\ohm>, color=red] (2,2)
         to[C=1<\farad>] (2,0) -- (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The postponed application of colors creates a problem if you want to use arrows for voltages, because the ``arrows'' are partially part of the path, partially nodes:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0){[red] to[V=1<\volt>] (0,2) }
         to[R=1<\ohm>] (2,2)
         to[C=1<\farad>] (2,0) -- (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 ...and that can become quite frustrating:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,0) to[V=1<\volt>, color=red] (0,2)
         to[R=1<\ohm>] (2,2)
         to[C=1<\farad>] (2,0) -- (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 In those cases, the only way out is to specify different paths (and/or using advanced voltages, see~\ref{sec:vif-anchors})
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw[color=red]
   (0,0) to[V=1<\volt>, color=red] (0,2);
   \draw (0,2) to[R=1<\ohm>] (2,2)
         to[C=1<\farad>] (2,0) -- (0,0)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Fill colors}
 \label{sec:fill-colors}
 
 Since version 0.9.0, you can also fill most shapes with a color (the manual specifies which ones are fillable or not). The syntax is quite intuitive:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
     (0,2) node[and port, fill=yellow](myand1){1}
     (0,0) node[and port, fill=cyan](myand2){2}
@@ -10905,12 +10905,12 @@ Since version 0.9.0, you can also fill most shapes with a color (the manual spec
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 This fill color will override any color defined by the style (see section~\ref{sec:styling-fillcolor}). If you want to override a style fill color with no-fill for a specific component, you need to override the style --- it's a bit unfortunate, but should be an exceptional thing anyway. Notice that in simple case \IndexKey{fill opacity} works, but don't count too much on it.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{logic ports/fill=cyan!30!white}
     \draw[red] (-0.5,3) -- (-0.5, -1);
@@ -10923,11 +10923,11 @@ This fill color will override any color defined by the style (see section~\ref{s
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can combine shape colors with fill colors, too, but you should use the explicit \texttt{color} option style for this:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw[color=red]
     (0,2) node[and port, fill=yellow](myand1) {1}
     (0,0) node[and port, fill=cyan] (myand2){2}
@@ -10935,9 +10935,9 @@ You can combine shape colors with fill colors, too, but you should use the expli
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   (0,2) node[and port, color=black](myand1){1}
   (0,0) node[and port, color=blue, fill=cyan](myand2){2}
@@ -10945,14 +10945,14 @@ You can combine shape colors with fill colors, too, but you should use the expli
   (myand1.out) -| (myxnor.in 1)
   (myand2.out) -| (myxnor.in 2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsubsection{Background colors different from white}
 \label{sec:background-colors-different}
 
 Notice also that the connection point is always filled, and the color \emph{tries} to follow the color of the filling of the component (but look at section~\ref{sec:transparent-poles}). Moreover, if you want to pass fill transparency down to path-style components, you \emph{have} to put it into the options of the \verb|\draw| command.
 
-\begin{LTXexample}[varwidth=true, pos=t]
+\begin{ctikzExample}[varwidth=true, pos=t]
 \begin{circuitikz}
     \fill[cyan] (0,3.0) rectangle (7,7);
     \draw [fill opacity=0.5] (1,6.5) to[generic, fill=white,o-o] ++(2,0);
@@ -10963,22 +10963,22 @@ Notice also that the connection point is always filled, and the color \emph{trie
     \draw [thick, color=green!50!black] (4,4) to [D,o-o,fill=yellow] ++(0,2) to[D*, fill=yellow]
         ++(2,0) to[D*,fill=yellow] ++(0,-2)  to[D, fill=red, o-o] ++(-2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 As you can see, the ``black'' components (as \texttt{D*}) follow the color of the line, not the fill.
 
 Note, however, that if you choose a colored background, for example with the \verb|\pagecolor{}| command or with other tricks, the nodes will be by default still filled with white.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \fill[color=blue] (-1,-1) rectangle (4,1);
     \draw[color=white] (0,0) to[R, o-o] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 You have two solutions for this. You can redefine the \IndexKey{o-o} (and the similar commands \IndexKey{-o}, \IndexKey{o-}, \IndexKey{*-o} and so on) with a blue filled ``open'' pole:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \tikzset{bcirc/.style={shape=ocirc, fill=blue}}
 \ctikzset{o-o/.style ={
     \circuitikzbasekey/bipole/nodes/left=bcirc,
@@ -10987,17 +10987,17 @@ You have two solutions for this. You can redefine the \IndexKey{o-o} (and the si
     \fill[color=blue] (-1,-1) rectangle (4,1);
     \draw[color=white] (0,0) to[R, o-o] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Also, since \texttt{v1.2.3}, you can set the key \IndexKey{open poles fill} (default: \texttt{white} which works for \texttt{ocirc}, \texttt{odiamondpole} and \texttt{osquarepole}):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[european]
     \ctikzset{open poles fill=blue}
     \fill[color=blue] (-1,-1) rectangle (4,1);
     \draw[color=white] (0,0) to[R, o-o] ++(3,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \section{FAQ: Frequently asked questions}
@@ -11020,39 +11020,39 @@ But really, your circuit definition is buggy, so the best thing to do is fix tha
 
 Nodes, in \TikZ, normally have a non-zero size even when they are empty; moreover, connections are supposed to join the border of nodes. Please study the following (pure \TikZ, not \Circuitikz):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \path (1,1) node (A){}; % empty node at (1,1)
     \draw (1,0) -- (A) -- (2,1); % surprise!
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 The gap is there because the node has a non-zero size (more in detail, its \texttt{inner sep} is by default different from zero). You can see it easily if you draw the node shape:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \path (1,1) node [draw=red](A){};
     \draw (1,0) -- (A) -- (2,1);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 The problem is that when you want to name a coordinate, in the sense of a dimensionless point, you should use a \texttt{coordinate}, \textbf{not} a node!
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{tikzpicture}
     \path (1,1) coordinate (A); % give a name to (1,1)
     \draw (1,0) -- (A) -- (2,1);% now it's ok!
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 Now, before version \texttt{1.2.1} (and since around \texttt{0.6}), \Circuitikz{} was detecting  when a connection was between nodes and sort-of added a \texttt{node.center} movement to the path. That in turn generated the need of hacks to draw the correct joining of lines, because that kind of movement broke the continuity of the path, like in this example:
 
-\begin{LTXexample}
+\begin{ctikzExample}
     \begin{tikzpicture}[line width=4pt]
     \path (1,1) node (A){};
     \draw (1,0) -- (A.center) (A) (A.center) -- (2,1);
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 You can see more examples and more reasonings on GitHub; start from the
 \href{https://github.com/circuitikz/circuitikz/issues/417}{issue detecting the join problem}, then
@@ -11064,72 +11064,72 @@ So finally it was decided\footnote{well, Romano decided, so you can blame him. \
 
 \faqQ How can I make part of the wires dashed (or colored)? This does not work:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0)
     to[short, dashed, red] ++(1,0)
     to [R] ++(2,0); % surprise!
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Nor this one, which is even stranger:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0)
     [dashed, red] -- ++(1,0)
     to [R] ++(2,0); % surprise!
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \faqA This is an effect on how \TikZ{} builds and draws path. As explained in the \TikZ{} manual,\footnote{in 3.1.5b, section~14, ``syntax for path specification''} most path options are globally valid for the whole path; color and dash/dot is one of this. You have two options in this case. The first one is to use two paths.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0) coordinate(a);
     \draw [dashed, red] (a) -- ++(1,0) coordinate(b);
     \draw (b) to [R] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The other one is to use \texttt{edge} operations\footnote{I took the idea form \href{https://tex.stackexchange.com/a/554905/38080}{this answer by \texttt{@LaTeXdraw-com} user on TeX.SE}, thanks!}; be sure to read about it on the \TikZ{} manual\footnote{in 3.1.5b, section~17.12, ``connecting nodes: use the \texttt{edge} operation''} --- but basically this is similar to the \texttt{to} operation but it builds another path (added at the end of the current path, like nodes are). This means that it can use different options, and that it \textbf{does not} move the path coordinates.
 
 So, for example:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0)
     edge[dashed, red] ++(1,0)
     % we have to move the path position here!
     ++(1,0) to [R] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The only problem with this approach is that the \texttt{edge}s are added \emph{after} the nodes, so it can create problems with nodes (look carefully!):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R,-o] ++(2,0)
     edge[dashed, red] ++(1,0)
     ++(1,0) to [R] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 So it's better, in this case, to add the nodes manually after the path (there is no perfect solution!):
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0) coordinate(a)
     edge[dashed, red] ++(1,0)
     ++(1,0) to [R] ++(2,0);
     \node [ocirc] at (a){};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 A more complex example can be seen (look at the comments!) in the following circuit.
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[american]
     \draw (0,0) to[R, v=$v_1$] ++(2,0)
         edge[dashed] ++(1,0)
@@ -11143,7 +11143,7 @@ A more complex example can be seen (look at the comments!) in the following circ
     ++(0,1) to[R] ++(0,2)
     (a) ++(-1,0) to[sV] ++(-2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{Errors when externalizing pictures}\label{faqs:externalize}
 
@@ -11166,13 +11166,13 @@ Just substitute every occurrence of the environment \verb!circuitikz! with \verb
 \faqQ How do I draw the voltage between two nodes?
 
 \faqA Between any two nodes there is an open circuit!
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz} \draw
   node[ocirc] (A) at (0,0) {}
   node[ocirc] (B) at (2,1) {}
   (A) to[open, v=$v$] (B)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \bigskip
 
@@ -11204,7 +11204,7 @@ In versions up to \texttt{1.2.7}, use for example \verb|\mbox{}| or define \verb
 Version 1.3.3 fixes the direction of the arrows in tunable elements; before this version, they were more or less random, now the arrow goes from bottom left to top right. You have the option to go back to the old behavior with \IndexKey[bipoles/fix tunable direction]{}\texttt{\textbackslash ctikzset\{bipoles/fix tunable direction=false\}}. As a compensation for the fuss, now the arrows are configurable.
 
 
-\begin{LTXexample}[pos=t]
+\begin{ctikzExample}[pos=t]
 \begin{circuitikz}[european]
     \draw (1,0) node{new default} (4,0) node{old default} (7,0) node{new!};
     \foreach [count=\i] \comp in
@@ -11218,7 +11218,7 @@ Version 1.3.3 fixes the direction of the arrows in tunable elements; before this
         \draw (6,-\i) to[\comp, name=E] ++(2,0);
     }
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 \section{Defining new components}
@@ -11267,12 +11267,12 @@ The suggested way to start working on a new component is to use the utilities of
 
 \geolrcoord{dampershape, fill=yellow}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0)
     to[damper] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 \end{document}
 \end{lstlisting}
 
@@ -11282,12 +11282,12 @@ This will compile to something like this (in this case, we are using a couple of
 
 \geolrcoord{dampershape, fill=yellow}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[R] ++(2,0)
     to[damper] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 The command \verb|circuitdescbip*| is used to show the component description (you can check the definition and the usage looking at \texttt{ctikzmanutils.sty} file, and the \verb|\geolrcoord| is used to show the main anchors (geographical plus \texttt{left} and \texttt{right}) of the component.
 
@@ -11376,12 +11376,12 @@ Now you can show it with:
 
 \geolrcoord{viscoeshape, fill=yellow}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[spring] ++(2,0)
     to[viscoe] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 \end{lstlisting}
 
 Obviously, at first you just have a component that is the same as the one you copied with another name.
@@ -11414,31 +11414,31 @@ which leads to:
 
 \geolrcoord{viscoeshape, fill=yellow}
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \draw (0,0) to[spring] ++(2,0)
     to[viscoe] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Now you can check if the voltage labels are correct for your new component:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}[]
     \draw (0,0) to[spring] ++(2,0)
     to[viscoe, v=V] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 If you think they are too tight or too loose, you can use a (developer-only) key to adjust the distance:
 
-\begin{LTXexample}
+\begin{ctikzExample}
 \begin{circuitikz}
     \ctikzset{bipoles/viscoe/voltage/additional shift/.initial=1}
     \draw (0,0) to[spring] ++(2,0)
     to[viscoe, v=V] ++(2,0);
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 Notice that by default the key \texttt{bipoles/\emph{mybipole}/voltage/additional shift} is not defined, so if you want to use it you must create it before (this is the meaning of the \texttt{.initial} here).
 
@@ -11519,7 +11519,7 @@ Here a series of examples, contributed by several people, is shown with their co
 \subsection{A red diode}
 \label{sec:a-red-diode}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1.4]\draw
   (0,0) to[C, l=10<\micro\farad>] (0,2) -- (0,3)
         to[R, l=2.2<\kilo\ohm>] (4,3) -- (4,2)
@@ -11529,13 +11529,13 @@ Here a series of examples, contributed by several people, is shown with their co
         to[cV, i=1, -*, v=$\SI{.3}{\kilo\ohm}\, i_1$] (4,2)
   (2,0) to[I, i=1<\milli\ampere>, *-*] (2,2)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{Using the (experimental) \texttt{siunitx} syntax}
 \label{sec:using-the-experimental}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1.2]\draw
   (0,0) node[ground] {}
         to[V=$e(t)$, *-*] (0,2) to[C=4<\nano\farad>] (2,2)
@@ -11549,10 +11549,10 @@ Here a series of examples, contributed by several people, is shown with their co
  {[anchor=south east] (0,2) node {1} (2,2) node {2} (4,2) node {3}}
 ;
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1.2]\draw
   (0,0) node[anchor=east] {B}
         to[short, o-*] (1,0)
@@ -11563,24 +11563,24 @@ Here a series of examples, contributed by several people, is shown with their co
   (3,0) -- (1,0)
   (1,2) to[short, -o] (0,2) node[anchor=east]{A}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{Photodiodes}
 \label{sec:photodiodes}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1]\draw
 	(0,0) node[transformer] (T) {}
 	(T.B2) to[pD] ($(T.B2)+(2,0)$) -| (3.5, -1)
 	(T.B1) to[pD] ($(T.B1)+(2,0)$)  -| (3.5, -1)
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{A Sallen-Key cell}
 \label{sec:a-sallen-key}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1]\draw
     (5,.5) node [op amp] (opamp) {}
     (0,0) node [left] {$U_{we}$} to [R, l=$R_d$, o-*] (2,0)
@@ -11590,13 +11590,13 @@ Here a series of examples, contributed by several people, is shown with their co
     (opamp.-) -| (3.5,2)
     (opamp.out) to [short, *-o] (7,.5) node [right] {$U_{wy}$}
 ;\end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{Mixing circuits and graphs}
 \label{sec:mixing-circuits-and}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
 \begin{circuitikz}[scale=1.2, american]\draw
   (0,2) to[I=1<\milli\ampere>] (2,2)
         to[R, l_=2<\kilo\ohm>, *-*] (0,0)
@@ -11619,13 +11619,13 @@ Here a series of examples, contributed by several people, is shown with their co
           (-1,1) -- (0,1) (1,-1) -- (0,-1);
    \end{scope}
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{RF circuit}
 \label{sec:rf-circuit}
 
-\begin{LTXexample}[pos=t,varwidth=true]
+\begin{ctikzExample}[pos=t,varwidth=true]
     \begin{circuitikz}[scale=1]
         \ctikzset{bipoles/detector/width=.35}
         \ctikzset{quadpoles/coupler/width=1}
@@ -11653,12 +11653,12 @@ Here a series of examples, contributed by several people, is shown with their co
         (c3.port4) to[detector,-o] ++(0,-1.5)
         ;
     \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{A styled low noise input stage}
 \label{sec:a-styled-low}
 
-\begin{LTXexample}[pos=t, box=hbox]
+\begin{ctikzExample}[pos=t, box=hbox]
 \ctikzloadstyle{romano}
 \scalebox{0.707}{%
 \begin{circuitikz}[american, romano circuit style]
@@ -11708,7 +11708,7 @@ Here a series of examples, contributed by several people, is shown with their co
     \node [anchor=north west] at ([yshift=-5pt]LNA.refv down) {AD8429};
 \end{circuitikz}
 } % scalebox
-\end{LTXexample}
+\end{ctikzExample}
 
 \subsection{An example with the \texttt{compatibility} option}
 \label{ex:compatibility}
@@ -11739,7 +11739,7 @@ Here a series of examples, contributed by several people, is shown with their co
 \subsection{3-phases block schematic}
 \label{sec:3-phases-block}
 
-\begin{LTXexample}[varwidth=true,pos=t]
+\begin{ctikzExample}[varwidth=true,pos=t]
 \begin{circuitikz}[smallR/.style={european resistor, resistors/scale=0.5}]
     \draw (0,0) node[tacdcshape, anchor=ac mid in](acdc){} to[smallR] ++(-2,0)
         -- coordinate(point) node[circ](){} ++(-.5,0);
@@ -11759,12 +11759,12 @@ Here a series of examples, contributed by several people, is shown with their co
         to[ooosource,prim=delta,sec=delta,tert=wye,invert] ++(1.5,0)
         to[tmultiwire] ++(.5,0) node[gridnode,anchor=left]{};
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{Using components in \texttt{pic}s (since \texttt{v1.8.0})}\label{sec:example-pics}
 
-\begin{LTXexample}[varwidth=true,pos=t]
+\begin{ctikzExample}[varwidth=true,pos=t]
 \tikzset{mypic/.pic = {
     \draw (0,0) coordinate(-in)
     % unnamed component
@@ -11801,14 +11801,14 @@ Here a series of examples, contributed by several people, is shown with their co
     \node[right] at (0, -2) {Iarr: \ctikzgetdirection{inner-r-Iarrow}};
     \node[right] at (0, -2.5) {LAB: \ctikzgetdirection{P2-ledlabel}};
 \end{tikzpicture}
-\end{LTXexample}
+\end{ctikzExample}
 
 \newpage
 \subsection{Automatic user-defined voltages, currents and flows (since \texttt{v1.8.5})}%
 \label{sec:example-auto-vif}
 
 
-\begin{LTXexample}[varwidth=true,pos=t, basicstyle=\footnotesize\ttfamily]
+\begin{ctikzExample}[varwidth=true,pos=t, basicstyle=\footnotesize\ttfamily]
 %% This can go to your preamble and/or a style file!
 %% setup voltage drawing macro: european style, but adding "+" and "-"
 \newcommand\eurVPMstyled[4]{% node, label, style, one ignored arguments
@@ -11853,7 +11853,7 @@ Here a series of examples, contributed by several people, is shown with their co
     to[R, l_=$R_2$, vpms^>={$v_2$}{blue}, fpow_={$P$}{red}] ++(4,0)
     to[L=$L$, i=$i$, v=$v_L$, f>^=$P_L$] ++(4,0); % traditional still working!
 \end{circuitikz}
-\end{LTXexample}
+\end{ctikzExample}
 
 
 % % changelog.tex will be updated by makefile from CHANGELOG.md

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -236,12 +236,12 @@
           ]}%
       }%
   }
-% \begin{LTXexample}[<settings>]
+% \begin{ctikzExample}[<settings>]
 % the front level environment. <settings> can be any keys as described inside
 % \ekvdefinekeys{ctikz/examples}. The following paragraph will be indented if
-% there's a blank line between \end{LTXexample} and the first line of the
+% there's a blank line between \end{ctikzExample} and the first line of the
 % paragraph (as with lists in LaTeX).
-\newenvironment{LTXexample}
+\newenvironment{ctikzExample}
   {\enverb{key-set=ctikz/examples, oarg-not-enverb, more-ignore=0}}
   {%
     \par
@@ -288,7 +288,7 @@
 % \ctikz@ex@codeOutside the key was used and we should rerun an \enverbExecute
 % (which only works on \enverbBody contents, so we restore those outside of the
 % environment).
-\AddToHook{env/LTXexample/after}
+\AddToHook{env/ctikzExample/after}
   {%
     \ifx\ctikz@ex@codeOutside\@empty
     \else

--- a/doc/ctikzmanutils.sty
+++ b/doc/ctikzmanutils.sty
@@ -30,6 +30,7 @@
 % for some example we need them...
 \usetikzlibrary{calc, fit, decorations, decorations.pathmorphing, tikzmark}
 \RequirePackage{upgreek}
+
 %
 % Example definitions using `enverb`
 %
@@ -38,6 +39,9 @@
 \newcommand*\ctikz@ex@codeOutside{} % collect code to execute after the env
 \newdimen\ctikz@ex@width % width available to the code
 \newsavebox\ctikz@ex@box % temporary box register
+% handle the 'store' key.
+% #1: the name of the storage
+% saves the contents currently in \enverbBody to the named storage.
 \newcommand*\ctikz@ex@dostore[1]
   {%
     \@ifundefined{ctikz@ex@storage@#1}%
@@ -46,6 +50,9 @@
     \expandafter\gappto\csname ctikz@ex@storage@#1\expandafter\endcsname
       \expandafter{\enverbBody}%
   }
+% handle the 'restore' key.
+% #1: the name of the storage
+% prepends \enverbBody with the contents of the named storage.
 \newcommand*\ctikz@ex@dorestore[1]
   {%
     \@ifundefined{ctikz@ex@storage@#1}
@@ -60,41 +67,95 @@
   }
 \ekvdefinekeys{ctikz/examples}
   {
-    % like showexpl but fewer choices
+    % pos=<t|b|l>
+    %   where to output the results
+    %     t: on top of the code
+    %     b: below the code
+    %     l: left of the code
      choice-store pos       = \ctikz@ex@pos{t,b,l}
     ,initial      pos       = l
+    % hsep=<dimen>
+    %   how much separation to put between the results and the code for pos=l
     ,dimen        hsep      = \ctikz@ex@hsep
     ,initial      hsep      = 1.5\columnsep
+    % vsep=<dimen>
+    %   how much separation to put between the results and the code for pos=t/b
     ,dimen        vsep      = \ctikz@ex@vsep
     ,initial      vsep      = \bigskipamount
+    % aboveskip=<dimen>
+    %   how much space to put above the environment
     ,dimen        aboveskip = \ctikz@ex@aboveskip
     ,initial      aboveskip = \medskipamount
+    % belowskip=<dimen>
+    %   how much space to put below the environment
     ,dimen        belowskip = \ctikz@ex@belowskip
     ,initial      belowskip = \medskipamount
-    ,store        width     = \ctikz@ex@reswd % max width if pos=l and varwidth
+    % width=<dimen> (late evaluation)
+    %   the width of the results box for box=varwidth/minipage, if this is 0pt
+    %   the default values will be
+    %     pos=l: 0.5\linewidth
+    %     pos=t/b: \linewidth
+    ,store        width     = \ctikz@ex@reswd
     ,initial      width     = 0pt
+    % box=<hbox|varwidth|minipage|default>
+    %   the type of box put around the results box (not visually but how to
+    %   determine the width)
+    %     hbox: simply use a \hbox (so natural width, no \par, no vertical
+    %       material)
+    %     varwidth: Use a `varwidth` environment around it
+    %     minipage: Use a `minipage` environment around it
+    %     default: the used boxing mechanism depends on pos:
+    %       pos=l: hbox
+    %       pos=t/b: minipage
     ,choice-store box       = \ctikz@ex@boxtype
       {hbox=h, varwidth=v, minipage=m, default=d}
     ,initial      box       = default
-    % is only used for pos=t or pos=b, for pos=l we always use variable width
+    % varwidth=[<t|true|f|false>]
+    %   backwards compatibility, sets box=varwidth without a value or with
+    %   true/t, sets box=default with false/f.
     ,nmeta        varwidth  = box=varwidth
     ,choice       varwidth  =
       {
         true=\ekvmorekv{box=varwidth}, t=\ekvmorekv{box=varwidth},
         false=\ekvmorekv{box=default}, f=\ekvmorekv{box=default}
       }
+    % only code=[<true|false>]
+    %   true/-NoValue-: there'll be no results box
+    %   false: revert the setting
     ,boolTF       only code = \ctikz@ex@onlycodeTF
+    % exec outside=[<true|false>]
+    %   true/-NoValue-: the code will be executed outside the environment (using
+    %     the generic env/<env>/after hook).
+    %   false: revert this setting
+    %   This will also call 'only code' with the same value!
     ,boolTF       exec outside = \ctikz@ex@execOutsideTF
-    ,dataT        store     = \ctikz@ex@store
-    ,dataT        restore   = \ctikz@ex@restore
-    ,code         clear storage =
-      \global\expandafter\let\csname  ctikz@ex@storage@#1\endcsname\ctikz@undef
     ,also meta    exec outside = {only code={#1}}
     ,also nmeta   exec outside = only code
+    % store=<name>
+    %   if used the code will be stored in a named storage for later use (see
+    %   'restore'). Multiple environments using the same storage name will
+    %   result in the code being appended to the existing stored code in this
+    %   storage.
+    ,dataT        store     = \ctikz@ex@store
+    % restore=<name>
+    %   restore the code of the named storage, meaning it'll be prepended to the
+    %   code of this environment for the results box (but not for the listing!)
+    ,dataT        restore   = \ctikz@ex@restore
+    % clear storage=<name>
+    %   forget the contents of the named storage (handled on the spot, so a key
+    %   combination `store=foo, clear storage=foo` would first clear `foo` and
+    %   then store the environment contents into `foo` after the environment was
+    %   processed.
+    ,code         clear storage =
+      \global\expandafter\let\csname  ctikz@ex@storage@#1\endcsname\ctikz@undef
     % collect unknown keys for lstlisting
     ,unknown      code      = \appto\ctikz@ex@lstopts{,#1={#2}}
     ,unknown      noval     = \appto\ctikz@ex@lstopts{,#1}
   }
+% handle the boxing inside the results box
+% #1: default box type if 'box=default'
+% This will call \ctikz@ex@fbox with the argument based on the current
+% box-setting.
 \newcommand*\ctikz@ex@handleboxtype[1] % #1 = default case
   {%
     \if\ctikz@ex@boxtype d%
@@ -113,6 +174,9 @@
     \fi\fi\fi
   }
 % print the result of the collected code
+% Control will first be given to \ctikz@ex@handleboxtype which will call
+% \ctikz@ex@fbox eventually. But first we need to set a suitable default width
+% for 'width=0pt' (or anything that evaluates to 0pt inside \dimexpr).
 \newcommand*\ctikz@ex@printresult
   {%
     \if\ctikz@ex@pos l%
@@ -127,10 +191,11 @@
       \ctikz@ex@handleboxtype{m}%
     \fi
   }
-\newcommand*\ctikz@ex@vcenter{\raisebox{.5\dimexpr\depth-\height\relax}}
 % output a vcentered framed box for the results
 % additionally the output (together with the framed box) will be in the box
 % register \ctikz@ex@box
+% #1: the contents to box up (should be \enverbExecute nested in a suitable box
+%     construct based on the 'box' key).
 \newcommand*\ctikz@ex@fbox[1]
   {%
     \sbox\ctikz@ex@box
@@ -151,7 +216,7 @@
       }%
     $\vcenter{\copy\ctikz@ex@box}$% vcenter matches minipage [c]
   }
-% output vcentered code listing
+% output a vcentered code listing if pos=l, otherwise output a code listing
 \newcommand*\ctikz@ex@printcode
   {%
     \ctikz@ex@onlycodeTF{\@firstofone}%
@@ -171,6 +236,11 @@
           ]}%
       }%
   }
+% \begin{LTXexample}[<settings>]
+% the front level environment. <settings> can be any keys as described inside
+% \ekvdefinekeys{ctikz/examples}. The following paragraph will be indented if
+% there's a blank line between \end{LTXexample} and the first line of the
+% paragraph (as with lists in LaTeX).
 \newenvironment{LTXexample}
   {\enverb{key-set=ctikz/examples, oarg-not-enverb, more-ignore=0}}
   {%
@@ -208,12 +278,16 @@
       }%
     \par
     \vskip\ctikz@ex@belowskip
-    \@endparenv
     \ctikz@ex@store\ctikz@ex@dostore
     \ctikz@ex@execOutsideTF
       {\global\let\ctikz@ex@codeOutside\enverbBody}%
       {}%
+    \@endparenv
   }
+% handling of the 'exec outside' key. If there are contents inside
+% \ctikz@ex@codeOutside the key was used and we should rerun an \enverbExecute
+% (which only works on \enverbBody contents, so we restore those outside of the
+% environment).
 \AddToHook{env/LTXexample/after}
   {%
     \ifx\ctikz@ex@codeOutside\@empty


### PR DESCRIPTION
This documents much of the `enverb` based code and renames the environment to `ctikzExample`.